### PR TITLE
Fix binary path save

### DIFF
--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -19,6 +19,7 @@
 #include "syncconnector.h"
 #include <QtGui>
 #include <QObject>
+#include <QMessageBox>
 #include <iostream>
 
 namespace mfk
@@ -261,6 +262,15 @@ void SyncConnector::folderListReceived(QNetworkReply *reply)
 
 void SyncConnector::spawnSyncthingProcess(std::string filePath)
 {
+  if (!checkIfFileExists(tr(filePath.c_str())))
+  {
+    QMessageBox msgBox;
+    msgBox.setText("Could not find Syncthing.");
+    msgBox.setInformativeText("Are you sure the path is correct?");
+    msgBox.setStandardButtons(QMessageBox::Ok);
+    msgBox.setDefaultButton(QMessageBox::Ok);
+    msgBox.exec();
+  }
   if (!systemUtil.isSyncthingRunning())
   {
     mpSyncProcess = new QProcess(this);
@@ -305,6 +315,23 @@ void SyncConnector::ignoreSslErrors(QNetworkReply *reply)
 void SyncConnector::onSslError(QNetworkReply* reply)
 {
   reply->ignoreSslErrors();
+}
+
+
+//------------------------------------------------------------------------------------//
+
+bool SyncConnector::checkIfFileExists(QString path)
+{
+  QFileInfo checkFile(path);
+  // check if file exists and if yes: Is it really a file and no directory?
+  if (checkFile.exists() && checkFile.isFile())
+  {
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 

--- a/src/syncconnector.h
+++ b/src/syncconnector.h
@@ -97,6 +97,7 @@ namespace connector
     private:
       void ignoreSslErrors(QNetworkReply *reply);
       void checkFolderList();
+      bool checkIfFileExists(QString path);
       ConnectionStateCallback mConnectionStateCallback = nullptr;
       ConnectionHealthCallback mConnectionHealthCallback = nullptr;
       ProcessSpawnedCallback mProcessSpawnedCallback = nullptr;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -120,6 +120,7 @@ void Window::closeEvent(QCloseEvent *event)
         if (filePathLine->text().toStdString() != mCurrentSyncthingPath)
         {
           mCurrentSyncthingPath = filePathLine->text().toStdString();
+          saveSettings();
           spawnSyncthingApp();
         }
         event->ignore();
@@ -279,8 +280,8 @@ void Window::showFileBrowser()
 //------------------------------------------------------------------------------------//
 void Window::pathEnterPressed()
 {
-  mCurrentSyncthingPath = filePathLine->text().toStdString();
-  spawnSyncthingApp();
+    mCurrentSyncthingPath = filePathLine->text().toStdString();
+    spawnSyncthingApp();
 }
 
 //------------------------------------------------------------------------------------//

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -62,6 +62,7 @@ Window::Window()
     connect(authCheckBox, SIGNAL(stateChanged(int)), this,
       SLOT(authCheckBoxChanged(int)));
     connect(filePathBrowse, SIGNAL(clicked()), this, SLOT(showFileBrowser()));
+    connect(filePathLine, SIGNAL(returnPressed()), this, SLOT(pathEnterPressed()));
   
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(settingsGroupBox);
@@ -82,6 +83,7 @@ Window::Window()
             break;
           case kSyncthingProcessState::ALREADY_RUNNING:
             appSpawnedLabel->setText(tr("Already Runnning"));
+            break;
           default:
             break;
         }
@@ -115,6 +117,11 @@ void Window::closeEvent(QCloseEvent *event)
     if (trayIcon->isVisible())
     {
         hide();
+        if (filePathLine->text().toStdString() != mCurrentSyncthingPath)
+        {
+          mCurrentSyncthingPath = filePathLine->text().toStdString();
+          spawnSyncthingApp();
+        }
         event->ignore();
     }
 }
@@ -265,15 +272,22 @@ void Window::showFileBrowser()
                                           tr("Open Syncthing"), "", tr(""));
   mCurrentSyncthingPath = filename.toStdString();
   filePathLine->setText(filename);
-  saveSettings();
   spawnSyncthingApp();
 }
 
 
 //------------------------------------------------------------------------------------//
+void Window::pathEnterPressed()
+{
+  mCurrentSyncthingPath = filePathLine->text().toStdString();
+  spawnSyncthingApp();
+}
+
+//------------------------------------------------------------------------------------//
 
 void Window::spawnSyncthingApp()
 {
+  saveSettings();
   mSyncConnector->spawnSyncthingProcess(mCurrentSyncthingPath);
 }
 
@@ -342,7 +356,7 @@ void Window::createSettingsGroupBox()
 
   filePathGroupBox = new QGroupBox(tr("Syncthing Application"));
 
-  filePathLabel = new QLabel("Path");
+  filePathLabel = new QLabel("Binary with Path");
 
   filePathLine = new QLineEdit(mCurrentSyncthingPath.c_str());
   filePathLine->setFixedWidth(maximumWidth / devicePixelRatio());

--- a/src/window.h
+++ b/src/window.h
@@ -73,6 +73,7 @@ private slots:
     void showFileBrowser();
     void showGitPage();
     void folderClicked();
+    void pathEnterPressed();
 
 private:
     void createSettingsGroupBox();


### PR DESCRIPTION
The path to syncthing would not be saved if entered manually.
This feature-branch ensures we check whether the file actually exists (and thus the path is valid at all).
If not, we display a warning message.

Related to: https://github.com/sieren/QSyncthingTray/issues/8