### PR TITLE
Fixed Seg Fault on Exit

### DIFF
--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -273,8 +273,8 @@ void SyncConnector::spawnSyncthingProcess(std::string filePath)
   }
   if (!systemUtil.isSyncthingRunning())
   {
-    mpSyncProcess = new QProcess(this);
-    connect(mpSyncProcess, SIGNAL(stateChanged(QProcess::ProcessState)),
+    mpSyncProcess = std::unique_ptr<QProcess>(new QProcess(this));
+    connect(mpSyncProcess.get(), SIGNAL(stateChanged(QProcess::ProcessState)),
       this, SLOT(syncThingProcessSpawned(QProcess::ProcessState)));
     QString processPath = filePath.c_str();
     QStringList launchArgs;
@@ -340,7 +340,7 @@ bool SyncConnector::checkIfFileExists(QString path)
 
 SyncConnector::~SyncConnector()
 {
-  if (mpSyncProcess != nullptr)
+  if (mpSyncProcess)
   {
     mpSyncProcess->kill();
   }

--- a/src/syncconnector.h
+++ b/src/syncconnector.h
@@ -107,7 +107,7 @@ namespace connector
     QNetworkAccessManager mHealthUrl;
     QNetworkAccessManager mFolderUrl;
     std::unique_ptr<QWebView> mpWebView;
-    QProcess *mpSyncProcess;
+    std::unique_ptr<QProcess> mpSyncProcess;
     std::list<std::pair<std::string, std::string>> mFolders;
     std::unique_ptr<QTimer> connectionHealthTimer;
     std::pair<std::string, std::string> mAuthentication;


### PR DESCRIPTION
We have moved the Raw Pointer into a
unique one to examin whether it is set or not.
The previous check would occasionally cause
a seg fault.

https://github.com/sieren/QSyncthingTray/issues/16