### PR TITLE
Bugfix: Fix repeating path warning

### DIFF
--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -302,9 +302,9 @@ void SyncConnector::shutdownProcessPosted(QNetworkReply *reply)
 
 //------------------------------------------------------------------------------------//
 
-void SyncConnector::spawnSyncthingProcess(std::string filePath)
+void SyncConnector::spawnSyncthingProcess(std::string filePath, const bool onSetPath)
 {
-  if (!checkIfFileExists(tr(filePath.c_str())))
+  if (!checkIfFileExists(tr(filePath.c_str())) && onSetPath)
   {
     QMessageBox msgBox;
     msgBox.setText("Could not find Syncthing.");

--- a/src/syncconnector.h
+++ b/src/syncconnector.h
@@ -85,7 +85,7 @@ namespace connector
     void setConnectionHealthCallback(ConnectionHealthCallback cb);
     void setProcessSpawnedCallback(ProcessSpawnedCallback cb);
     void showWebView();
-    void spawnSyncthingProcess(std::string filePath);
+    void spawnSyncthingProcess(std::string filePath, const bool onSetPath = false);
     void shutdownSyncthingProcess();
     std::list<std::pair<std::string, std::string>> getFolders();
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -308,7 +308,7 @@ void Window::showFileBrowser()
 void Window::pathEnterPressed()
 {
     mCurrentSyncthingPath = mpFilePathLine->text().toStdString();
-    spawnSyncthingApp();
+    mpSyncConnector->spawnSyncthingProcess(mCurrentSyncthingPath, true);
 }
 
 //------------------------------------------------------------------------------------//


### PR DESCRIPTION
Fixed an issue where - if SyncThing is spawned
by a 3rd party and no path is specified - a message
asking for the correct path would occour bound
to the timer checking for a running binary.
https://github.com/sieren/QSyncthingTray/issues/20