### PR TITLE
Show Additional Warning on wrong path

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -525,6 +525,10 @@ void Window::saveSettings()
   mSettings.setValue("url", mCurrentUrl.toString());
   mSettings.setValue("username", mpUserNameLineEdit->text());
   mSettings.setValue("userpassword", userPassword->text());
+  if (mSettings.value("syncthingpath").toString().toStdString() != mCurrentSyncthingPath)
+  {
+    pathEnterPressed();
+  }
   mSettings.setValue("syncthingpath", tr(mCurrentSyncthingPath.c_str()));
   mSettings.setValue("monochromeIcon", mIconMonochrome);
 }


### PR DESCRIPTION
Previously the warning would only pop up when the user
hit Enter after entering the path.
Now the message will appear when the settings are saved and the
path is wrong, thus preventing a silent fail.

https://github.com/sieren/QSyncthingTray/issues/20