### PR TITLE
Show missing OpenSSL Library Message

### DIFF
--- a/src/QSyncThingTray.pro
+++ b/src/QSyncThingTray.pro
@@ -1,7 +1,8 @@
 HEADERS       = window.h \
                 syncconnector.h \
-                platforms/darwin/posixUtils.hpp \
+                platforms/darwin/macUtils.hpp \
                 platforms/windows/winUtils.hpp \
+                platforms/linux/posixUtils.hpp \
                 processmonitor.hpp \
                 platforms.hpp \
                 apihandler.hpp

--- a/src/platforms.hpp
+++ b/src/platforms.hpp
@@ -20,8 +20,10 @@
 
 #ifdef _WIN32
 #include "platforms/windows/winUtils.hpp"
-#elif (defined(__APPLE__) && defined(__MACH__)) || defined(__linux__)
-#include "platforms/darwin/posixUtils.hpp"
+#elif defined(__linux__)
+#include "platforms/linux/posixUtils.hpp"
+#elif (defined(__APPLE__) && defined(__MACH__))
+#include "platforms/darwin/macUtils.hpp"
 #endif
 
 namespace mfk
@@ -31,8 +33,10 @@ namespace sysutils
   
 #ifdef _WIN32
 using SystemUtility = platforms::windows::WinUtils;
-#elif (defined(__APPLE__) && defined(__MACH__)) || defined(__linux__)
-using SystemUtility = platforms::darwin::PosixUtils;
+#elif defined(__linux__)
+using SystemUtility = platforms::linux::PosixUtils;
+#elif (defined(__APPLE__) && defined(__MACH__))
+using SystemUtility = platforms::darwin::MacUtils;
 #endif
   
 } // sysutils

--- a/src/platforms/darwin/macUtils.hpp
+++ b/src/platforms/darwin/macUtils.hpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <string>
 #include <iostream>
+#include <CoreFoundation/CoreFoundation.h>
 
 namespace mfk
 {
@@ -28,8 +29,13 @@ namespace platforms
 {
 namespace darwin
 {
-  struct PosixUtils
+  struct MacUtils
   {
+    std::string getSSLLibraryText()
+    {
+      return std::string("HTTPS is not supported on this platform. "
+        "This can happen when OpenSSL is missing.");
+    }
     static bool isBinaryRunning(std::string binary)
     {
       const char* someapp = binary.c_str();

--- a/src/platforms/windows/winUtils.hpp
+++ b/src/platforms/windows/winUtils.hpp
@@ -34,6 +34,12 @@ namespace windows
 {
   struct WinUtils
   {
+    std::string getSSLLibraryText()
+    {
+      return std::string("In order to use HTTPS URLs on Windows, the "
+        "<a href='http://slproweb.com/products/Win32OpenSSL.html'>OpenSSL "
+        "Library</a> is required. Please install and restart QSyncthingTray.");
+    }
     static bool isBinaryRunning(std::string binary)
     {
       const char *syncapp = binary.c_str();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -178,6 +178,12 @@ void Window::setIcon(int index)
 
 void Window::testURL()
 {
+  std::string validateUrl = mpSyncthingUrlLineEdit->text().toStdString();
+  std::size_t foundSSL = validateUrl.find("https");
+  if (foundSSL!=std::string::npos)
+  {
+    validateSSLSupport();
+  }
   mCurrentUrl = QUrl(mpSyncthingUrlLineEdit->text());
   mCurrentUserName = mpUserNameLineEdit->text().toStdString();
   mCurrentUserPassword = userPassword->text().toStdString();
@@ -650,6 +656,22 @@ void Window::createDefaultSettings()
   mSettings.setValue("doSettingsExist", true);
   mSettings.setValue("launchSyncthingAtStartup", false);
 }
+
+
+//------------------------------------------------------------------------------------//
+
+void Window::validateSSLSupport()
+{
+  if (!QSslSocket::supportsSsl())
+  {
+    QMessageBox msgBox(this);
+    msgBox.setWindowTitle("OpenSSL Not Found");
+    msgBox.setTextFormat(Qt::RichText);   //this is what makes the links clickable
+    msgBox.setText(mfk::sysutils::SystemUtility().getSSLLibraryText().c_str());
+    msgBox.exec();
+  }
+}
+
 
 //------------------------------------------------------------------------------------//
 

--- a/src/window.h
+++ b/src/window.h
@@ -21,6 +21,7 @@
 
 #include "syncconnector.h"
 #include "processmonitor.hpp"
+#include "platforms.hpp"
 #include <QSystemTrayIcon>
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
@@ -89,6 +90,7 @@ private:
     void showMessage(std::string title, std::string body);
     void createFoldersMenu();
     void createDefaultSettings();
+    void validateSSLSupport();
     int getCurrentVersion(std::string reply);
 
     QTabWidget *mpSettingsTabsWidget;


### PR DESCRIPTION
Qt doesn't bundle OpenSSL for legal reasons.
This is not a problem on OSX/Linux but on Windows.
We are now displaying a message with a link to
the OpenSSL Library.
https://github.com/sieren/QSyncthingTray/issues/34