### PR TITLE
Use QWebEngine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,5 +79,5 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     get_target_property(QtCore_location Qt5::Core LOCATION)
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
-qt5_use_modules(QSyncthingTray Widgets Network WebKitWidgets)
+qt5_use_modules(QSyncthingTray Widgets Network WebEngineWidgets)
 

--- a/src/QSyncThingTray.pro
+++ b/src/QSyncThingTray.pro
@@ -7,18 +7,22 @@ HEADERS       = window.h \
                 platforms.hpp \
                 apihandler.hpp \
                 startuptab.hpp \
-                utilities.hpp
+                utilities.hpp \
+                syncwebview.h \
+                syncwebpage.h
 SOURCES       = main.cpp \
                 window.cpp \
                 syncconnector.cpp \
                 processmonitor.cpp \
-                startuptab.cpp
+                startuptab.cpp \
+                syncwebview.cpp \
+                syncwebpage.cpp
 RESOURCES     = \
                 qsyncthing.qrc
 
 QT += widgets
 QT += network
-QT += webkitwidgets
+QT += webenginewidgets
 
 # install
 target.path = binary/

--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -62,6 +62,10 @@ void SyncConnector::setURL(QUrl url, std::string username, std::string password,
   network.clearAccessCache();
   QNetworkReply *reply = network.get(request);
   requestMap[reply] = kRequestMethod::urlTested;
+  if (mpSyncWebView != nullptr)
+  {
+    mpSyncWebView->updateConnection(url, mAuthentication);
+  }
 }
 
 
@@ -69,7 +73,13 @@ void SyncConnector::setURL(QUrl url, std::string username, std::string password,
 
 void SyncConnector::showWebView()
 {
-
+  if (mpSyncWebView != nullptr)
+  {
+    mpSyncWebView->close();
+  }
+  mpSyncWebView = std::unique_ptr<SyncWebView>(new SyncWebView(mCurrentUrl,
+     mAuthentication));
+  mpSyncWebView->show();
 }
 
 

--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -69,21 +69,7 @@ void SyncConnector::setURL(QUrl url, std::string username, std::string password,
 
 void SyncConnector::showWebView()
 {
-  if (mpWebView != nullptr)
-  {
-    mpWebView->close();
-  }
-  std::unique_ptr<QWebViewClose> pWeb(new QWebViewClose());
-  mpWebView = std::move(pWeb);
-  mpWebView->show();
-  connect(mpWebView->page()->networkAccessManager(),
-    SIGNAL(sslErrors(QNetworkReply*, const QList<QSslError> & )),
-    this,
-    SLOT(onSslError(QNetworkReply*)));
-  mpWebView->load(mCurrentUrl);
-  mpWebView->setStyle(QStyleFactory::create("Fusion"));
-  sysutils::SystemUtility().showDockIcon(true);
-  mpWebView->raise();
+
 }
 
 
@@ -500,15 +486,6 @@ std::string SyncConnector::trafficToString(T traffic)
   return strTraffic;
 }
 
-
-//------------------------------------------------------------------------------------//
-
-void QWebViewClose::closeEvent(QCloseEvent *event)
-{
-UNUSED(event);
-  mfk::sysutils::SystemUtility().showDockIcon(false);
-  close();
-}
   
 } // connector
 } //mfk

--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -66,6 +66,7 @@ void SyncConnector::setURL(QUrl url, std::string username, std::string password,
   {
     mpSyncWebView->updateConnection(url, mAuthentication);
   }
+  didShowSSLWarning = false;
 }
 
 
@@ -416,6 +417,21 @@ std::list<FolderNameFullPath> SyncConnector::getFolders()
 void SyncConnector::ignoreSslErrors(QNetworkReply *reply)
 {
   QList<QSslError> errorsThatCanBeIgnored;
+  std::string urlString = mCurrentUrl.toString().toStdString();
+  std::size_t found = urlString.find("http:");
+  if (found != std::string::npos && !didShowSSLWarning)
+  {
+    QMessageBox *msgBox = new QMessageBox;
+    msgBox->setText("SSL Warning");
+    msgBox->setInformativeText("The SyncThing Server seems to have HTTPS activated, "
+      "however you are using HTTP. Please make sure to use a correct URL.");
+    msgBox->setStandardButtons(QMessageBox::Ok);
+    msgBox->setDefaultButton(QMessageBox::Ok);
+    msgBox->setAttribute(Qt::WA_DeleteOnClose);
+    msgBox->show();
+    msgBox->setFocus();
+    didShowSSLWarning = true;
+  }
   
   errorsThatCanBeIgnored<<QSslError(QSslError::HostNameMismatch);
   errorsThatCanBeIgnored<<QSslError(QSslError::SelfSignedCertificate);

--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -79,7 +79,19 @@ void SyncConnector::showWebView()
   }
   mpSyncWebView = std::unique_ptr<SyncWebView>(new SyncWebView(mCurrentUrl,
      mAuthentication));
+  connect(mpSyncWebView.get(), &SyncWebView::close, this, &SyncConnector::webViewClosed);
   mpSyncWebView->show();
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncConnector::webViewClosed()
+{
+  disconnect(mpSyncWebView.get(), &SyncWebView::close,
+    this, &SyncConnector::webViewClosed);
+  mpSyncWebView->deleteLater();
+  mpSyncWebView.release();
 }
 
 

--- a/src/syncconnector.h
+++ b/src/syncconnector.h
@@ -98,6 +98,7 @@ namespace connector
     void checkConnectionHealth();
     void syncThingProcessSpawned(QProcess::ProcessState newState);
     void shutdownProcessPosted(QNetworkReply *reply);
+    void webViewClosed();
 
   private:
     void ignoreSslErrors(QNetworkReply *reply);

--- a/src/syncconnector.h
+++ b/src/syncconnector.h
@@ -27,7 +27,6 @@
 #include <QNetworkRequest>
 #include <QAuthenticator>
 #include <QNetworkReply>
-#include <QWebView>
 #include <QProcess>
 #include <memory>
 #include <functional>
@@ -131,7 +130,6 @@ namespace connector
     };
     QHash<QNetworkReply*, kRequestMethod> requestMap;
 
-    std::unique_ptr<QWebViewClose> mpWebView;
     std::unique_ptr<QProcess> mpSyncProcess;
     std::unique_ptr<QProcess> mpSyncthingNotifierProcess;
     std::list<FolderNameFullPath> mFolders;
@@ -146,12 +144,6 @@ namespace connector
     std::unique_ptr<api::APIHandlerBase> mAPIHandler;
   };
 
-  class QWebViewClose : public QWebView
-  {
-    Q_OBJECT;
-    public slots:
-      void closeEvent(QCloseEvent *event) override;
-  };
 } // connector
 } // mfk
 

--- a/src/syncconnector.h
+++ b/src/syncconnector.h
@@ -34,6 +34,7 @@
 #include <thread>
 #include <utility>
 #include "platforms.hpp"
+#include "syncwebview.h"
 #include "apihandler.hpp"
 
 QT_BEGIN_NAMESPACE
@@ -130,6 +131,7 @@ namespace connector
     };
     QHash<QNetworkReply*, kRequestMethod> requestMap;
 
+    std::unique_ptr<SyncWebView> mpSyncWebView;
     std::unique_ptr<QProcess> mpSyncProcess;
     std::unique_ptr<QProcess> mpSyncthingNotifierProcess;
     std::list<FolderNameFullPath> mFolders;

--- a/src/syncconnector.h
+++ b/src/syncconnector.h
@@ -28,6 +28,7 @@
 #include <QAuthenticator>
 #include <QNetworkReply>
 #include <QProcess>
+#include <QSettings>
 #include <memory>
 #include <functional>
 #include <map>
@@ -110,6 +111,8 @@ namespace connector
     void lastSyncedFilesReceived(QNetworkReply *reply);
     void killProcesses();
     int getCurrentVersion(std::string reply);
+
+    bool didShowSSLWarning;
 
     template <typename T>
     std::string trafficToString(T traffic);

--- a/src/syncwebpage.cpp
+++ b/src/syncwebpage.cpp
@@ -1,0 +1,56 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
+#include <iostream>
+#include "syncwebpage.h"
+
+//------------------------------------------------------------------------------------//
+
+SyncWebPage::SyncWebPage()
+{
+  connect(this, &QWebEnginePage::authenticationRequired,
+    this, &SyncWebPage::requireAuthentication);
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncWebPage::updateConnInfo(QUrl url, Authentication authInfo)
+{
+  mAuthInfo = authInfo;
+  setUrl(url);
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncWebPage::requireAuthentication(
+  const QUrl &requestUrl, QAuthenticator *authenticator)
+{
+  authenticator->setUser(tr(mAuthInfo.first.c_str()));
+  authenticator->setPassword(tr(mAuthInfo.first.c_str()));
+}
+
+
+//------------------------------------------------------------------------------------//
+
+bool SyncWebPage::certificateError(const QWebEngineCertificateError &certificateError)
+{
+  return true; // TODO: Figure out whether there is a syncthing CA so we can use the
+               // real certificate
+}

--- a/src/syncwebpage.cpp
+++ b/src/syncwebpage.cpp
@@ -30,6 +30,15 @@ SyncWebPage::SyncWebPage()
 
 //------------------------------------------------------------------------------------//
 
+SyncWebPage::~SyncWebPage()
+{
+  disconnect(this, &QWebEnginePage::authenticationRequired,
+          this, &SyncWebPage::requireAuthentication);
+}
+
+
+//------------------------------------------------------------------------------------//
+
 void SyncWebPage::updateConnInfo(QUrl url, Authentication authInfo)
 {
   mAuthInfo = authInfo;
@@ -54,3 +63,8 @@ bool SyncWebPage::certificateError(const QWebEngineCertificateError &certificate
   return true; // TODO: Figure out whether there is a syncthing CA so we can use the
                // real certificate
 }
+
+//------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------//
+// EOF
+//------------------------------------------------------------------------------------//

--- a/src/syncwebpage.h
+++ b/src/syncwebpage.h
@@ -1,0 +1,29 @@
+#ifndef SYNCWEBPAGE_H
+#define SYNCWEBPAGE_H
+
+#include <QObject>
+#include <QAuthenticator>
+#include <QtWebEngineWidgets/QWebEnginePage>
+
+using Authentication = std::pair<std::string, std::string>;
+
+class SyncWebPage : public QWebEnginePage
+{
+  
+public:
+  SyncWebPage();
+  SyncWebPage(QObject *parent) : QWebEnginePage(parent) { }
+  void updateConnInfo(QUrl url, Authentication authInfo);
+
+private slots:
+  void requireAuthentication(const QUrl & requestUrl, QAuthenticator * authenticator);
+
+protected:
+  virtual bool certificateError(const QWebEngineCertificateError & certificateError) override;
+  
+private:
+  Authentication mAuthInfo;
+
+};
+
+#endif // SYNCWEBPAGE_H

--- a/src/syncwebpage.h
+++ b/src/syncwebpage.h
@@ -1,3 +1,21 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
 #ifndef SYNCWEBPAGE_H
 #define SYNCWEBPAGE_H
 
@@ -5,13 +23,18 @@
 #include <QAuthenticator>
 #include <QtWebEngineWidgets/QWebEnginePage>
 
+//------------------------------------------------------------------------------------//
+
 using Authentication = std::pair<std::string, std::string>;
+
+//------------------------------------------------------------------------------------//
 
 class SyncWebPage : public QWebEnginePage
 {
   
 public:
   SyncWebPage();
+  ~SyncWebPage();
   SyncWebPage(QObject *parent) : QWebEnginePage(parent) { }
   void updateConnInfo(QUrl url, Authentication authInfo);
 
@@ -27,3 +50,7 @@ private:
 };
 
 #endif // SYNCWEBPAGE_H
+//------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------//
+// EOF
+//------------------------------------------------------------------------------------//

--- a/src/syncwebview.cpp
+++ b/src/syncwebview.cpp
@@ -1,0 +1,141 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
+
+#include "syncwebview.h"
+#include <QContextMenuEvent>
+#include <QWebEngineProfile>
+#include <QWebEngineSettings>
+#include <functional>
+
+//------------------------------------------------------------------------------------//
+
+SyncWebView::SyncWebView(QUrl url, Authentication authInfo) :
+   mSyncThingUrl(url)
+  ,mAuthInfo(authInfo)
+  ,mContextMenu(this)
+{
+  initWebView();
+  setupMenu();
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncWebView::initWebView()
+{
+  QWebEngineProfile *profile = QWebEngineProfile::defaultProfile();
+  profile->setPersistentCookiesPolicy(QWebEngineProfile::ForcePersistentCookies);
+  mpPageView = new SyncWebPage(profile);
+
+  QWebEngineSettings* settings = mpPageView->settings();
+  settings->setAttribute(QWebEngineSettings::WebAttribute::JavascriptEnabled, true);
+  settings->setAttribute(QWebEngineSettings::WebAttribute::AutoLoadImages,true);
+  settings->setAttribute(QWebEngineSettings::WebAttribute::LocalContentCanAccessRemoteUrls, true);
+  mpPageView->load(mSyncThingUrl);
+  setPage(mpPageView);
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncWebView::updateConnection(QUrl url, Authentication authInfo)
+{
+  mpPageView->updateConnInfo(url, authInfo);
+  setPage(mpPageView);
+  reload();
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncWebView::closeEvent(QCloseEvent *event)
+{
+  QWebEngineView::closeEvent(event);
+  mfk::sysutils::SystemUtility().showDockIcon(false);
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncWebView::show()
+{
+  QWebEngineView::show();
+  setFocusPolicy(Qt::ClickFocus);
+  setEnabled(true);
+  setFocus();
+  mfk::sysutils::SystemUtility().showDockIcon(true);
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncWebView::setupMenu()
+{
+  QAction *shrtCut = pageAction(QWebEnginePage::Cut);
+  shrtCut->setShortcut(QKeySequence::Cut);
+  QAction *shrtCopy = pageAction(QWebEnginePage::Copy);;
+  shrtCopy->setShortcut(QKeySequence::Copy);
+  QAction *shrtPaste = pageAction(QWebEnginePage::Paste);
+  shrtPaste->setShortcut(QKeySequence::Paste);
+  QAction *slctAll = pageAction(QWebEnginePage::SelectAll);
+  slctAll->setShortcut(QKeySequence::SelectAll);
+  
+  using namespace std::placeholders;
+  addActions(std::bind(&QWidget::addAction, &mContextMenu, _1),
+             shrtCut, shrtCopy, shrtPaste, slctAll);
+  addActions(std::bind(&QWebEngineView::addAction, this, _1),
+             shrtCut, shrtCopy, shrtPaste, slctAll);
+  
+  mContextMenu.addSeparator();
+  QAction *shrtReload = pageAction(QWebEnginePage::Reload);
+  addActions(std::bind(&QWebEngineView::addAction, this, _1), shrtReload);
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncWebView::contextMenuEvent(QContextMenuEvent * event)
+{
+  mContextMenu.exec(event->globalPos());
+}
+
+
+//------------------------------------------------------------------------------------//
+
+template<typename F, typename T, typename... TArgs>
+void SyncWebView::addActions(F &&funct, T action, TArgs... Actions)
+{
+  funct(action);
+  addActions(funct, std::forward<TArgs>(Actions)...);
+}
+
+
+//------------------------------------------------------------------------------------//
+
+template<typename F, typename T>
+void SyncWebView::addActions(F &&funct, T action)
+{
+  funct(action);
+}
+
+
+//------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------//
+// EOF
+//------------------------------------------------------------------------------------//

--- a/src/syncwebview.h
+++ b/src/syncwebview.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
+#ifndef SYNCWEBVIEW_H
+#define SYNCWEBVIEW_H
+
+#include <QDialog>
+#include <QMenu>
+#include <QObject>
+#include <QtWebEngineWidgets/QWebEngineView>
+#include "utilities.hpp"
+#include "syncwebpage.h"
+
+//------------------------------------------------------------------------------------//
+
+class SyncWebView : public QWebEngineView
+{
+
+public:
+  SyncWebView() = default;
+  SyncWebView(QUrl url, Authentication authInfo);
+  void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+  void show();
+  virtual void contextMenuEvent(QContextMenuEvent * event) override;
+  void updateConnection(QUrl url, Authentication authInfo);
+
+private:
+  void initWebView();
+  void setupMenu();
+  
+  SyncWebPage *mpPageView;
+  QUrl mSyncThingUrl;
+  Authentication mAuthInfo;
+  
+  QMenu mContextMenu;
+  
+  template<typename F, typename T, typename... TArgs>
+  void addActions(F &&funct, T action, TArgs... Actions);
+  
+  template<typename F, typename T>
+  void addActions(F &&funct, T action);
+};
+
+#endif // SYNCWEBVIEW_H

--- a/src/syncwebview.h
+++ b/src/syncwebview.h
@@ -30,25 +30,36 @@
 
 class SyncWebView : public QWebEngineView
 {
-
+  Q_OBJECT;
 public:
   SyncWebView() = default;
   SyncWebView(QUrl url, Authentication authInfo);
+  ~SyncWebView() = default;
+
   void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
   void show();
   virtual void contextMenuEvent(QContextMenuEvent * event) override;
   void updateConnection(QUrl url, Authentication authInfo);
 
+signals:
+  void close();
+
 private:
   void initWebView();
   void setupMenu();
   
-  SyncWebPage *mpPageView;
+  std::unique_ptr<SyncWebPage> mpPageView;
   QUrl mSyncThingUrl;
   Authentication mAuthInfo;
   
   QMenu mContextMenu;
   
+  std::unique_ptr<QAction> shrtCut;
+  std::unique_ptr<QAction> shrtPaste;
+  std::unique_ptr<QAction> shrtCopy;
+  std::unique_ptr<QAction> slctAll;
+
+
   template<typename F, typename T, typename... TArgs>
   void addActions(F &&funct, T action, TArgs... Actions);
   
@@ -57,3 +68,7 @@ private:
 };
 
 #endif // SYNCWEBVIEW_H
+//------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------//
+// EOF
+//------------------------------------------------------------------------------------//

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -688,11 +688,12 @@ void Window::onStartAnimation(bool animate)
     : tr(kAnimatedIconSet.front().c_str());
   if (!animate || !mShouldAnimateIcon)
   {
-    mpAnimatedIconMovie->stop();
+    mShouldStopAnimation = true;
   }
   else if (animate && mShouldAnimateIcon
     && mpAnimatedIconMovie->state() != QMovie::Running)
   {
+    mShouldStopAnimation = false;
     mpAnimatedIconMovie->setFileName(iconToAnimate);
     mpAnimatedIconMovie->start();
   }
@@ -703,6 +704,11 @@ void Window::onStartAnimation(bool animate)
 
 void Window::onUpdateIcon()
 {
+  if (mShouldStopAnimation && mpAnimatedIconMovie->currentFrameNumber() ==
+    mpAnimatedIconMovie->frameCount() - 1)
+  {
+    mpAnimatedIconMovie->stop();
+  }
   mpTrayIcon->setIcon(QIcon(QPixmap::fromImage(mpAnimatedIconMovie->currentImage())));
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -684,7 +684,7 @@ void Window::validateSSLSupport()
 
 void Window::onStartAnimation(bool animate)
 {
-  QString iconToAnimate = mpMonochromeIconBox ? tr(kAnimatedIconSet.back().c_str())
+  QString iconToAnimate = mIconMonochrome ? tr(kAnimatedIconSet.back().c_str())
     : tr(kAnimatedIconSet.front().c_str());
   if (!animate || !mShouldAnimateIcon)
   {

--- a/src/window.h
+++ b/src/window.h
@@ -28,7 +28,6 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QSettings>
-#include <QWebView>
 #include <QProcess>
 #include <QFileDialog>
 #include <QTabWidget>

--- a/src/window.h
+++ b/src/window.h
@@ -147,6 +147,7 @@ private:
     bool mIconMonochrome;
     bool mNotificationsEnabled;
     bool mShouldAnimateIcon;
+    bool mShouldStopAnimation;
     int mLastConnectionState;
 
   };


### PR DESCRIPTION
Replace deprecated QWebKit with QWebEngine.
Show a warning when user is attempting to connect to SSL Site but uses http://
Smoother Icon rotation animation.
Fixed a bug where only the monochrome icon would appear spinning.

Adressed issues:
https://github.com/sieren/QSyncthingTray/issues/57
https://github.com/sieren/QSyncthingTray/issues/55
https://github.com/sieren/QSyncthingTray/issues/58
https://github.com/sieren/QSyncthingTray/issues/50

Potentially:
https://github.com/sieren/QSyncthingTray/issues/59