### PR TITLE
Additional Shutdown Settings

### DIFF
--- a/src/startuptab.cpp
+++ b/src/startuptab.cpp
@@ -65,11 +65,16 @@ void StartupTab::initGUI()
   
   mpAppSpawnedLabel = new QLabel(tr("Not started"));
   
+  mpShutdownOnExitBox = new QCheckBox(tr("Shutdown on Exit"));
+  Qt::CheckState shutdownState = mShouldShutdownOnExit ? Qt::Checked : Qt::Unchecked;
+  mpShutdownOnExitBox->setCheckState(shutdownState);
+  
   filePathLayout->addWidget(mpFilePathLine,2, 0, 1, 4);
   filePathLayout->addWidget(mpFilePathBrowse,3, 0, 1, 1);
   filePathLayout->addWidget(mpAppSpawnedLabel, 3, 1, 1, 1);
   
   filePathLayout->addWidget(mpShouldLaunchSyncthingBox, 0, 0);
+  filePathLayout->addWidget(mpShutdownOnExitBox, 4, 0, 1, 2);
   mpFilePathGroupBox->setLayout(filePathLayout);
   mpFilePathGroupBox->setMinimumWidth(400);
   mpFilePathGroupBox->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
@@ -105,7 +110,9 @@ void StartupTab::initGUI()
   connect(mpINotifyBrowse, SIGNAL(clicked()), this, SLOT(showINotifyFileBrowser()));
   connect(mpINotifyFilePath, SIGNAL(returnPressed()), this, SLOT(pathEnterPressed()));
   connect(mpShouldLaunchINotify, SIGNAL(stateChanged(int)), this,
-          SLOT(launchINotifyBoxChanged(int)));
+    SLOT(launchINotifyBoxChanged(int)));
+  connect(mpShutdownOnExitBox, SIGNAL(stateChanged(int)), this,
+    SLOT(shutdownOnExitBoxChanged(int)));
   
 
   launcherLayout->addWidget(mpFilePathGroupBox);
@@ -180,6 +187,14 @@ void StartupTab::launchSyncthingBoxChanged(int state)
 
 //------------------------------------------------------------------------------------//
 
+void StartupTab::shutdownOnExitBoxChanged(int state)
+{
+  mShouldShutdownOnExit = state == Qt::Checked ? true : false;
+  saveSettings();
+}
+
+//------------------------------------------------------------------------------------//
+
 
 void StartupTab::launchINotifyBoxChanged(int state)
 {
@@ -216,6 +231,7 @@ void StartupTab::saveSettings()
     mpSyncConnector->spawnINotifyProcess(mCurrentINotifyPath, mShouldLaunchINotify);
   }
   mSettings.setValue("launchINotifyAtStartup", mShouldLaunchINotify);
+  mSettings.setValue("ShutdownOnExit", mShouldShutdownOnExit);
 }
 
 
@@ -227,6 +243,7 @@ void StartupTab::loadSettings()
   mShouldLaunchSyncthing = mSettings.value("launchSyncthingAtStartup").toBool();
   mCurrentINotifyPath = mSettings.value("inotifypath").toString().toStdString();
   mShouldLaunchINotify = mSettings.value("launchINotifyAtStartup").toBool();
+  mShouldShutdownOnExit = mSettings.value("ShutdownOnExit").toBool();
 }
 
 

--- a/src/startuptab.hpp
+++ b/src/startuptab.hpp
@@ -74,6 +74,7 @@ public:
 private slots:
   void launchSyncthingBoxChanged(int state);
   void launchINotifyBoxChanged(int state);
+  void shutdownOnExitBoxChanged(int state);
   void pathEnterPressed();
   void showFileBrowser();
   void showINotifyFileBrowser();
@@ -99,9 +100,11 @@ private:
   QPushButton *mpINotifyBrowse;
   QLabel *mpINotifySpawnedLabel;
   QCheckBox *mpShouldLaunchINotify;
+  QCheckBox *mpShutdownOnExitBox;
   
   bool mShouldLaunchSyncthing;
   bool mShouldLaunchINotify;
+  bool mShouldShutdownOnExit;
   std::string mCurrentSyncthingPath;
   std::string mCurrentINotifyPath;
 

--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -483,8 +483,9 @@ int SyncConnector::getCurrentVersion(std::string reply)
 
 void SyncConnector::killProcesses()
 {
+  QSettings shutdownSettings("sieren", "QSyncthingTray");
   if (mpSyncProcess != nullptr
-      && mpSyncProcess->state() == QProcess::Running)
+      && shutdownSettings.value("ShutdownOnExit").toBool())
   {
     shutdownSyncthingProcess();
     bool hasFinished = mpSyncProcess->waitForFinished(10000);

--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -486,8 +486,12 @@ void SyncConnector::killProcesses()
   if (mpSyncProcess != nullptr
       && mpSyncProcess->state() == QProcess::Running)
   {
-    mpSyncProcess->kill();
-    mpSyncProcess->waitForFinished();
+    shutdownSyncthingProcess();
+    bool hasFinished = mpSyncProcess->waitForFinished(10000);
+    if (!hasFinished)
+    {
+        mpSyncProcess->kill();
+    }
   }
   if (mpSyncthingNotifierProcess != nullptr
       && mpSyncthingNotifierProcess->state() == QProcess::Running)

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -536,7 +536,6 @@ void Window::createActions()
 
 void Window::quit()
 {
-  mpSyncConnector->shutdownSyncthingProcess();
   qApp->quit();
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -705,6 +705,7 @@ void Window::createDefaultSettings()
   mSettings.setValue("url", tr("http://127.0.0.1:8384"));
   mSettings.setValue("monochromeIcon", false);
   mSettings.setValue("WebZoomFactor", 1.0);
+  mSettings.setValue("ShutdownOnExit", true);
   mSettings.setValue("notificationsEnabled", true);
   mSettings.setValue("doSettingsExist", true);
   mSettings.setValue("launchSyncthingAtStartup", false);


### PR DESCRIPTION
Added a checkbox to the Start Up Tab to let the user decide whether we should shutdown Syncthing when leaving QST.

https://github.com/sieren/QSyncthingTray/issues/66