### PR TITLE
Dont kill Syncthing Process

### DIFF
--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -488,11 +488,7 @@ void SyncConnector::killProcesses()
       && shutdownSettings.value("ShutdownOnExit").toBool())
   {
     shutdownSyncthingProcess();
-    bool hasFinished = mpSyncProcess->waitForFinished(10000);
-    if (!hasFinished)
-    {
-        mpSyncProcess->kill();
-    }
+    mpSyncProcess->waitForFinished();
   }
   if (mpSyncthingNotifierProcess != nullptr
       && mpSyncthingNotifierProcess->state() == QProcess::Running)


### PR DESCRIPTION
Killing the process might cause an automatic respawn.
Thus we trust the process to shutdown by itself after
we posted the shutdown command.
https://github.com/sieren/QSyncthingTray/issues/66