### PR TITLE
Dont use discrete GPU on Mac

### DIFF
--- a/src/Info.plist
+++ b/src/Info.plist
@@ -10,5 +10,7 @@
 	<true/>
 	<key>LSUIElement</key>
 	<true/>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Add Key/Value to Info.plist to disable switching to the
discrete GPU.

Adresses: https://github.com/sieren/QSyncthingTray/issues/94