### PR TITLE
Change Namespace to gnu_linux

### DIFF
--- a/src/platforms.hpp
+++ b/src/platforms.hpp
@@ -30,11 +30,10 @@ namespace qst
 {
 namespace sysutils
 {
-  
 #ifdef _WIN32
 using SystemUtility = platforms::windows::WinUtils;
 #elif defined(__linux__)
-using SystemUtility = platforms::linux::PosixUtils;
+using SystemUtility = platforms::gnu_linux::PosixUtils;
 #elif (defined(__APPLE__) && defined(__MACH__))
 using SystemUtility = platforms::darwin::MacUtils;
 #endif

--- a/src/platforms/linux/posixUtils.hpp
+++ b/src/platforms/linux/posixUtils.hpp
@@ -27,7 +27,7 @@ namespace qst
 {
 namespace platforms
 {
-namespace linux
+namespace gnu_linux
 {
   struct PosixUtils
   {


### PR DESCRIPTION
On some platforms linux may be defined, thus causing
compiler errors.