### PR TITLE
Work around Qt Memory Leaks

### DIFF
--- a/src/syncconnector.h
+++ b/src/syncconnector.h
@@ -102,6 +102,7 @@ namespace connector
     void checkConnectionHealth();
     void syncThingProcessSpawned(QProcess::ProcessState newState);
     void shutdownProcessPosted(QNetworkReply *reply);
+    void testUrlAvailability();
     void webViewClosed();
 
   private:
@@ -143,6 +144,7 @@ namespace connector
     std::list<FolderNameFullPath> mFolders;
     LastSyncedFileList mLastSyncedFiles;
     std::unique_ptr<QTimer> mpConnectionHealthTimer;
+    std::unique_ptr<QTimer> mpConnectionAvailabilityTimer;
     std::pair<std::string, std::string> mAuthentication;
     std::shared_ptr<SyncConnector> mpSyncConnector;
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -143,28 +143,37 @@ void Window::closeEvent(QCloseEvent *event)
 
 void Window::setIcon(int index)
 {
-  QIcon icon;
-  std::pair<std::string, std::string> iconSet = mIconMonochrome ?
-    kIconSet.back() : kIconSet.front();
-  switch(index)
-  {
-    case 0:
-      icon = QIcon(iconSet.first.c_str());
-      break;
-    case 1:
-      icon = QIcon(iconSet.second.c_str());
-      break;
-    default:
-      icon = QIcon(iconSet.second.c_str());
-      break;
-  }
-  if (mpAnimatedIconMovie->state() != QMovie::Running)
-  {
-    mpTrayIcon->setIcon(icon);
-  }
-  setWindowIcon(icon);
+  // temporary workaround as setIcon seems to leak memory
+  // https://bugreports.qt.io/browse/QTBUG-23658?jql=text%20~%20%22setIcon%20memory%22
+  // https://bugreports.qt.io/browse/QTBUG-16113?jql=text%20~%20%22setIcon%20memory%22
 
-  mpTrayIcon->setToolTip("Syncthing");
+  if (index != mLastIconIndex)
+  {
+    QIcon icon;
+    std::pair<std::string, std::string> iconSet = mIconMonochrome ?
+      kIconSet.back() : kIconSet.front();
+    switch(index)
+    {
+      case 0:
+        icon = QIcon(iconSet.first.c_str());
+        break;
+      case 1:
+        icon = QIcon(iconSet.second.c_str());
+        break;
+      default:
+        icon = QIcon(iconSet.second.c_str());
+        break;
+    }
+
+    if (mpAnimatedIconMovie->state() != QMovie::Running)
+    {
+      mpTrayIcon->setIcon(icon);
+    }
+    setWindowIcon(icon);
+
+    mpTrayIcon->setToolTip("Syncthing");
+    mLastIconIndex = index;
+  }
 }
 
 

--- a/src/window.h
+++ b/src/window.h
@@ -144,6 +144,7 @@ private:
     QSystemTrayIcon *mpTrayIcon = nullptr;
     QMenu *mpTrayIconMenu = nullptr;
     QUrl mCurrentUrl;
+    int mLastIconIndex = -1;
 
     std::string mCurrentUserName;
     std::string mCurrentUserPassword;


### PR DESCRIPTION
Improve connection timeout handling.

Workaround Qt Memory Leak:
Qt seems to leak memory when setIcon is called:
https://bugreports.qt.io/browse/QTBUG-16113?jql=text%20~%20%22setIcon%20memory%22
https://bugreports.qt.io/browse/QTBUG-26263?jql=text%20~%20%22setIcon%20memory%22
https://bugreports.qt.io/browse/QTBUG-23658?jql=text%20~%20%22setIcon%20memory%22

Temporarily double-checking if the icon we are going to set
isnt the same as the one already being displayed.

Adresses:
https://github.com/sieren/QSyncthingTray/issues/106

