### PR TITLE
Fix Connection Health Timer

### DIFF
--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -335,6 +335,7 @@ void SyncConnector::onSettingsChanged()
 {
   mConnectionHealthTime = std::round(
     1000 * mSettings.value("pollingInterval").toDouble());
+  mConnectionHealthTime = mConnectionHealthTime == 0 ? 1000 : mConnectionHealthTime;
 }
 
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -40,7 +40,7 @@
 
 
 //! Layout
-#define currentVersion "v0.4.5"
+#define currentVersion "v0.4.6"
 #define maximumWidth 400
 static const std::list<std::pair<std::string, std::string>> kIconSet(
   {{":/images/syncthingBlue.png", ":/images/syncthingGrey.png"},


### PR DESCRIPTION
Due to changes in the Settingsmodel the Connection Health
Timer might be initialized with 0.
This should never be the case as it will result in high CPU Usage.
We are making sure this value is at least 1s.