### PR TITLE
Support Syncthing v13 and use API from Config

### DIFF
--- a/src/apihandler.hpp
+++ b/src/apihandler.hpp
@@ -129,20 +129,6 @@ namespace api
       return {curInBytes/kBytesToKilobytes, curOutBytes/kBytesToKilobytes};
     }
     
-    QString getCurrentAPIKey(QByteArray reply)
-    {
-      QString apiKey;
-      if (reply.size() > 0)
-      {
-        QString m_DownloadedData = static_cast<QString>(reply);
-        QJsonDocument replyDoc = QJsonDocument::fromJson(m_DownloadedData.toUtf8());
-        QJsonObject replyData = replyDoc.object();
-        QJsonObject guiData = replyData["gui"].toObject();
-        apiKey =  guiData["apiKey"].toString();
-      }
-      return apiKey;
-    }
-    
     LastSyncedFileList getLastSyncedFiles(QByteArray reply)
     {
       QString m_DownloadedData = static_cast<QString>(reply);

--- a/src/apihandler.hpp
+++ b/src/apihandler.hpp
@@ -260,11 +260,22 @@ namespace api
       return result;
     }
   };
+
+  // Syncthing API V13 Specializations
+  struct V13API : public V12API
+  {
+    const int version = 13;
+    using V12API::getConnections;
+  };
+
   
   inline APIHandlerBase *APIHandlerBase::getAPIForVersion(int version)
   {
     switch (version)
     {
+      case 13:
+        return new V13API;
+        break;
       case 12:
         return new V12API;
         break;
@@ -272,7 +283,7 @@ namespace api
         return new V11API;
         break;
       default:
-        return new V12API;
+        return new V13API;
     }
   }
   

--- a/src/apihandler.hpp
+++ b/src/apihandler.hpp
@@ -50,6 +50,8 @@ namespace api
 
   struct APIHandlerBase
   {
+    const int version = 0;
+
     std::pair<QString, bool> getConnectionInfo(QNetworkReply *reply)
     {
       QString result;
@@ -197,6 +199,8 @@ namespace api
   // Syncthing API V11 Specializations
   struct V12API : public APIHandlerBase
   {
+    const int version = 12;
+
     ConnectionHealthStatus getConnections(QByteArray reply) override
     {
       ConnectionHealthStatus result;
@@ -231,6 +235,8 @@ namespace api
   // Syncthing API V11 Specializations
   struct V11API : public APIHandlerBase
   {
+    const int version = 11;
+
     ConnectionHealthStatus getConnections(QByteArray reply) override
     {
       ConnectionHealthStatus result;

--- a/src/apihandler.hpp
+++ b/src/apihandler.hpp
@@ -197,6 +197,35 @@ namespace api
   // API Specializations
   
   // Syncthing API V11 Specializations
+  struct V11API : public APIHandlerBase
+  {
+    const int version = 11;
+
+    ConnectionHealthStatus getConnections(QByteArray reply) override
+    {
+      ConnectionHealthStatus result;
+      result.emplace("state", "0");
+      if (reply.size() == 0)
+      {
+        result.emplace("activeConnections", QString("0"));
+        result.emplace("totalConnections", QString("0"));
+      }
+      else
+      {
+        result.clear();
+        result.emplace("state", "1");
+        QString m_DownloadedData = static_cast<QString>(reply);
+        QJsonDocument replyDoc = QJsonDocument::fromJson(m_DownloadedData.toUtf8());
+        QJsonObject replyData = replyDoc.object();
+        QJsonObject connectionArray = replyData["connections"].toObject();
+        result.emplace("activeConnections", QString::number(connectionArray.size()));
+        result.emplace("totalConnections", QString::number(connectionArray.size()));
+      }
+      return result;
+    }
+  };
+
+  // Syncthing API V12 Specializations
   struct V12API : public APIHandlerBase
   {
     const int version = 12;
@@ -225,37 +254,8 @@ namespace api
           QJsonObject jObj = it->toObject();
           active += jObj.find("connected").value().toBool() ? 1 : 0;
         }
-        result.emplace("activeConnections", QString(active));
-        result.emplace("totalConnections", QString(connectionArray.size()));
-      }
-      return result;
-    }
-  };
-  
-  // Syncthing API V11 Specializations
-  struct V11API : public APIHandlerBase
-  {
-    const int version = 11;
-
-    ConnectionHealthStatus getConnections(QByteArray reply) override
-    {
-      ConnectionHealthStatus result;
-      result.emplace("state", "0");
-      if (reply.size() == 0)
-      {
-        result.emplace("activeConnections", QString("0"));
-        result.emplace("totalConnections", QString("0"));
-      }
-      else
-      {
-        result.clear();
-        result.emplace("state", "1");
-        QString m_DownloadedData = static_cast<QString>(reply);
-        QJsonDocument replyDoc = QJsonDocument::fromJson(m_DownloadedData.toUtf8());
-        QJsonObject replyData = replyDoc.object();
-        QJsonObject connectionArray = replyData["connections"].toObject();
-        result.emplace("activeConnections", QString(connectionArray.size()));
-        result.emplace("totalConnections", QString(connectionArray.size()));
+        result.emplace("activeConnections", QString::number(active));
+        result.emplace("totalConnections", QString::number(connectionArray.size()));
       }
       return result;
     }

--- a/src/platforms/darwin/macUtils.hpp
+++ b/src/platforms/darwin/macUtils.hpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <iostream>
 #include <Carbon/Carbon.h>
+#include <QProcessEnvironment>
+#include <QString>
 #define UNUSED(x) (void)(x)
 
 namespace qst
@@ -85,6 +87,13 @@ namespace darwin
       }
       bool result = instances == '0' ? false : true;
       return result;
+    }
+
+    static QString getDefaultSyncthingConfig()
+    {
+      QString path = QProcessEnvironment::systemEnvironment().value("HOME", "~");
+      path.append("/Library/Application Support/Syncthing/config.xml");
+      return{path};
     }
 
     template<typename U, typename T>

--- a/src/platforms/linux/posixUtils.hpp
+++ b/src/platforms/linux/posixUtils.hpp
@@ -21,6 +21,8 @@
 #include <sstream>
 #include <string>
 #include <iostream>
+#include <QProcessEnvironment>
+#include <QString>
 #define UNUSED(x) (void)(x)
 
 namespace qst
@@ -66,6 +68,13 @@ namespace gnu_linux
       }
       bool result = instances == '0' ? false : true;
       return result;
+    }
+
+    static QString getDefaultSyncthingConfig()
+    {
+      QString path = QProcessEnvironment::systemEnvironment().value("HOME", "~");
+      path.append("/.config/syncthing/config.xml");
+      return{path};
     }
 
     template<typename U, typename T>

--- a/src/platforms/windows/winUtils.hpp
+++ b/src/platforms/windows/winUtils.hpp
@@ -22,9 +22,11 @@
 #include <string>
 #include <iostream>
 #include <cstdio>
+#include <QProcessEnvironment>
 #include <windows.h>
 #include <tlhelp32.h>
 #include <comdef.h>
+#include <QString>
 #define UNUSED(x) (void)(x)
 
 namespace qst
@@ -74,6 +76,13 @@ namespace windows
       CloseHandle(snapshot);
       return result;
 
+    }
+
+    static QString getDefaultSyncthingConfig()
+    {
+      QString path = QProcessEnvironment::systemEnvironment().value("localappdata", "localappdata");
+      path.append("\\Syncthing\\config.xml");
+      return{path};
     }
 
     template<typename U, typename T>

--- a/src/startuptab.cpp
+++ b/src/startuptab.cpp
@@ -37,7 +37,6 @@ StartupTab::StartupTab(std::shared_ptr<qst::connector::SyncConnector> pSyncConne
     &StartupTab::processSpawnedChanged);
   
   mpSyncConnector->spawnSyncthingProcess(mCurrentSyncthingPath, mShouldLaunchSyncthing);
-  mpSyncConnector->spawnINotifyProcess(mCurrentINotifyPath, mShouldLaunchINotify);
 }
 
 
@@ -205,6 +204,7 @@ void StartupTab::launchINotifyBoxChanged(int state)
   mShouldLaunchINotify = state == Qt::Checked ? true : false;
   saveSettings();
   pathEnterPressed();
+  mpSyncConnector->checkAndSpawnINotifyProcess(false);
 }
 
 
@@ -231,12 +231,9 @@ void StartupTab::saveSettings()
     pathEnterPressed();
   }
   mSettings.setValue("inotifypath", tr(mCurrentINotifyPath.c_str()));
-  if (mSettings.value("launchINotifyAtStartup").toBool() != mShouldLaunchINotify)
-  {
-    mpSyncConnector->spawnINotifyProcess(mCurrentINotifyPath, mShouldLaunchINotify);
-  }
   mSettings.setValue("launchINotifyAtStartup", mShouldLaunchINotify);
   mSettings.setValue("ShutdownOnExit", mShouldShutdownOnExit);
+  mpSyncConnector->onSettingsChanged();
 }
 
 
@@ -256,6 +253,7 @@ void StartupTab::loadSettings()
 
 void StartupTab::pathEnterPressed()
 {
+  saveSettings();
   mCurrentSyncthingPath = mpFilePathLine->text().toStdString();
   mCurrentINotifyPath = mpINotifyFilePath->text().toStdString();
   if (mSettings.value("syncthingpath").toString().toStdString() != mCurrentSyncthingPath)
@@ -264,7 +262,7 @@ void StartupTab::pathEnterPressed()
   }
   if (mSettings.value("inotifypath").toString().toStdString() != mCurrentINotifyPath)
   {
-    mpSyncConnector->spawnINotifyProcess(mCurrentINotifyPath, true, true);
+    mpSyncConnector->checkAndSpawnINotifyProcess(true);
   }
 }
 

--- a/src/syncconnector.cpp
+++ b/src/syncconnector.cpp
@@ -124,7 +124,6 @@ void SyncConnector::urlTested(QNetworkReply* reply)
   if (reply->error() == QNetworkReply::TimeoutError ||
       reply->error() == QNetworkReply::ConnectionRefusedError)
   {
-    mAPIHandler = nullptr;
     mpConnectionAvailabilityTimer->start(1000);
   }
   else
@@ -133,7 +132,7 @@ void SyncConnector::urlTested(QNetworkReply* reply)
       api::V12API().getConnectionInfo(reply);
 
     int versionNumber = getCurrentVersion(connectionInfo.first);
-    if (mAPIHandler == nullptr)
+    if (mAPIHandler == nullptr || mAPIHandler->version != versionNumber)
     {
       mAPIHandler =
         std::unique_ptr<api::APIHandlerBase>(api::V12API().getAPIForVersion(versionNumber));

--- a/src/syncconnector.h
+++ b/src/syncconnector.h
@@ -80,10 +80,7 @@ namespace connector
       std::string filePath,
       const bool shouldSpawn,
       const bool onSetPath = false);
-    void spawnINotifyProcess(
-     std::string filePath,
-     const bool shouldSpawn,
-     const bool onSetPath = false);
+    void checkAndSpawnINotifyProcess(bool isRequestedExternal);
     void shutdownSyncthingProcess();
     std::list<FolderNameFullPath> getFolders();
     LastSyncedFileList getLastSyncedFiles();
@@ -114,10 +111,12 @@ namespace connector
     void currentConfigReceived(QNetworkReply* reply);
     void lastSyncedFilesReceived(QNetworkReply *reply);
     void killProcesses();
+    void shutdownINotifyProcess();
     int getCurrentVersion(QString reply);
     std::uint16_t mConnectionHealthTime = 1000;
     bool didShowSSLWarning;
     bool mSyncthingPaused = false;
+    bool mShouldLaunchINotify = false;
 
     template <typename T>
     QString trafficToString(T traffic);
@@ -149,7 +148,7 @@ namespace connector
     std::shared_ptr<SyncConnector> mpSyncConnector;
 
     std::string mSyncthingFilePath;
-    std::string mINotifyFilePath;
+    QString mINotifyFilePath;
     QString mAPIKey;
 
     qst::sysutils::SystemUtility systemUtil;

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <iomanip>
 #include <iostream>
+#include <QFile>
+#include <QXmlStreamReader>
 #include "platforms.hpp"
 
 static const int kBytesToKilobytes = 1024;
@@ -112,6 +114,28 @@ inline std::string getPathToFileName(std::string fileName)
   }
 }
 
+inline QString readAPIKey()
+{
+  QXmlStreamReader xmlReader;
+  QFile file(qst::sysutils::SystemUtility::getDefaultSyncthingConfig());
+  if (!file.open(QFile::ReadOnly | QFile::Text))
+  {
+    // For now return nothing as the user can input the
+    // apikey on the UI should the config file be somewhere else.
+    return "";
+  }
+  xmlReader.setDevice(&file);
+  xmlReader.readNext();
+  while(!xmlReader.atEnd())
+  {
+    if (xmlReader.name() == "apikey")
+    {
+      return xmlReader.readElementText();
+    }
+    xmlReader.readNext();
+  }
+  return "";
+}
 }
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -40,7 +40,7 @@
 
 
 //! Layout
-#define currentVersion "v0.4.7"
+#define currentVersion "v0.5.0"
 #define maximumWidth 400
 static const std::list<std::pair<std::string, std::string>> kIconSet(
   {{":/images/syncthingBlue.png", ":/images/syncthingGrey.png"},

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -182,6 +182,7 @@ void Window::setIcon(int index)
 
 void Window::testURL()
 {
+  saveSettings();
   std::string validateUrl = mpSyncthingUrlLineEdit->text().toStdString();
   std::size_t foundSSL = validateUrl.find("https");
   if (foundSSL!=std::string::npos)
@@ -453,6 +454,9 @@ void Window::createSettingsGroupBox()
   userPassword = new QLineEdit(mCurrentUserPassword.c_str());
   userPassword->setEchoMode(QLineEdit::Password);
 
+  mpAPIKeyLabel = new QLabel("API Key");
+  mpAPIKeyEdit = new QLineEdit(mSettings.value("apiKey").toString());
+
   mpUrlTestResultLabel = new QLabel("Not Tested");
 
   mpAuthCheckBox->setCheckState(Qt::Checked);
@@ -470,8 +474,10 @@ void Window::createSettingsGroupBox()
   iconLayout->addWidget(userPasswordLabel, 3, 2, 1 ,2);
   iconLayout->addWidget(mpUserNameLineEdit, 4, 0, 1, 2);
   iconLayout->addWidget(userPassword, 4, 2, 1, 2 );
-  iconLayout->addWidget(mpTestConnectionButton,5, 0, 1, 1);
-  iconLayout->addWidget(mpUrlTestResultLabel, 5, 1, 1, 2);
+  iconLayout->addWidget(mpAPIKeyLabel, 5, 0, 1, 2);
+  iconLayout->addWidget(mpAPIKeyEdit, 6, 0, 1, 4);
+  iconLayout->addWidget(mpTestConnectionButton,7, 0, 1, 1);
+  iconLayout->addWidget(mpUrlTestResultLabel, 7, 1, 1, 2);
   mpSettingsGroupBox->setLayout(iconLayout);
   mpSettingsGroupBox->setMinimumWidth(400);
   mpSettingsGroupBox->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
@@ -670,6 +676,7 @@ void Window::saveSettings()
   mSettings.setValue("notificationsEnabled", mNotificationsEnabled);
   mSettings.setValue("animationEnabled", mShouldAnimateIcon);
   mSettings.setValue("pollingInterval", mpSyncPollIntervalBox->value());
+  mSettings.setValue("apiKey", mpAPIKeyEdit->text());
   mpSyncConnector->onSettingsChanged();
 }
 
@@ -721,6 +728,7 @@ void Window::createDefaultSettings()
   checkAndSetValue("launchSyncthingAtStartup", false);
   checkAndSetValue("animationEnabled", false);
   checkAndSetValue("pollingInterval", 1.0);
+  checkAndSetValue("apiKey", qst::utilities::readAPIKey());
 }
 
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -58,6 +58,7 @@ Window::Window()
   , mSettings("sieren", "QSyncthingTray")
   , mpAnimatedIconMovie(new QMovie())
 {
+    createDefaultSettings();
     loadSettings();
     createSettingsGroupBox();
 
@@ -694,11 +695,6 @@ void Window::showAuthentication(bool show)
 
 void Window::loadSettings()
 {
-  if (!mSettings.value("doSettingsExist").toBool())
-  {
-    createDefaultSettings();
-  }
-
   mCurrentUrl.setUrl(mSettings.value("url").toString());
   if (mCurrentUrl.toString().length() == 0)
   {
@@ -716,17 +712,28 @@ void Window::loadSettings()
 
 void Window::createDefaultSettings()
 {
-  mSettings.setValue("url", tr("http://127.0.0.1:8384"));
-  mSettings.setValue("monochromeIcon", false);
-  mSettings.setValue("WebZoomFactor", 1.0);
-  mSettings.setValue("ShutdownOnExit", true);
-  mSettings.setValue("notificationsEnabled", true);
-  mSettings.setValue("doSettingsExist", true);
-  mSettings.setValue("launchSyncthingAtStartup", false);
-  mSettings.setValue("animationEnabled", false);
-  mSettings.setValue("pollingInterval", 1.0);
+  checkAndSetValue("url", tr("http://127.0.0.1:8384"));
+  checkAndSetValue("monochromeIcon", false);
+  checkAndSetValue("WebZoomFactor", 1.0);
+  checkAndSetValue("ShutdownOnExit", true);
+  checkAndSetValue("notificationsEnabled", true);
+  checkAndSetValue("doSettingsExist", true);
+  checkAndSetValue("launchSyncthingAtStartup", false);
+  checkAndSetValue("animationEnabled", false);
+  checkAndSetValue("pollingInterval", 1.0);
 }
 
+
+//------------------------------------------------------------------------------------//
+
+template <typename T>
+void Window::checkAndSetValue(QString key, T value)
+{
+  if (mSettings.value(key) == QVariant())
+  {
+    mSettings.setValue(key, value);
+  }
+}
 
 //------------------------------------------------------------------------------------//
 

--- a/src/window.h
+++ b/src/window.h
@@ -161,6 +161,9 @@ private:
     bool mShouldStopAnimation;
     int mLastConnectionState;
 
+    template <typename T>
+    void checkAndSetValue(QString key, T value);
+
     template <typename U, typename T>
     void setElements(U &&func, T uiElement);
 

--- a/src/window.h
+++ b/src/window.h
@@ -108,8 +108,10 @@ private:
 
     QLabel *userNameLabel;
     QLabel *userPasswordLabel;
+    QLabel *mpAPIKeyLabel;
     QLineEdit *mpUserNameLineEdit;
     QLineEdit *userPassword;
+    QLineEdit *mpAPIKeyEdit;
     QCheckBox *mpAuthCheckBox;
 
     QLabel *mpUrlTestResultLabel;


### PR DESCRIPTION
This PR adds a couple of fixes to QST:

- The API Key is now retrieved from the configuration file. QST will look into the default directory where `syncthing` stores its configuration and tries to retrieve it from the `config.xml`. As a user, there is now a field in the preferences to manually set the API Key, should the configuration reside in a different location.
- Fix a crash when resuming QST from Pause.
- Improved the way futured default settings are handled. We are now checking whether all settings are available on each launch, and if one is not (due to an update or an addition) we are adding the default setting to the Settings file.
- Fix a race-condition on Windows where syncthing-inotify might prevent syncthing from starting by acquiring a lock on its config file.

Adresses:
https://github.com/sieren/QSyncthingTray/issues/115
https://github.com/sieren/QSyncthingTray/issues/117
https://github.com/sieren/QSyncthingTray/issues/114 (partly)
https://github.com/sieren/QSyncthingTray/issues/119