### PR TITLE
Fix unsaved notifications

### DIFF
--- a/sources/qst/window.cpp
+++ b/sources/qst/window.cpp
@@ -664,6 +664,8 @@ void Window::saveSettings()
   mSettings.setValue("username", mpUserNameLineEdit->text());
   mSettings.setValue("userpassword", userPassword->text());
   mSettings.setValue("monochromeIcon", mIconMonochrome);
+  mNotificationsEnabled = mpNotificationsIconBox->checkState() ==
+  Qt::CheckState::Checked ? true : false;
   mSettings.setValue("notificationsEnabled", mNotificationsEnabled);
   mSettings.setValue("animationEnabled", mShouldAnimateIcon);
   mSettings.setValue("pollingInterval", mpSyncPollIntervalBox->value());


### PR DESCRIPTION
Notifications were not properly saved, presumably
something has gotten lost during a previous
rebase.

https://github.com/sieren/QSyncthingTray/issues/129