### PR TITLE
Dont kill syncthing if running

### DIFF
--- a/sources/qst/syncconnector.cpp
+++ b/sources/qst/syncconnector.cpp
@@ -393,11 +393,6 @@ void SyncConnector::spawnSyncthingProcess(
       emit(onProcessSpawned(kSyncthingProcessState::ALREADY_RUNNING));
     }
   }
-  else
-  {
-    shutdownSyncthingProcess();
-    killProcesses();
-  }
 }
 
 


### PR DESCRIPTION
A false if-statement causes syncthing to be shut down when already launched.

https://github.com/sieren/QSyncthingTray/issues/128