### PR TITLE
Migrate Settings to qst space

### DIFF
--- a/includes/CMakeLists.txt
+++ b/includes/CMakeLists.txt
@@ -13,6 +13,7 @@ set(qst_HEADERS
   ${qst_include_ROOT}/apihandler.hpp
   ${qst_include_ROOT}/platforms.hpp
   ${qst_include_ROOT}/processmonitor.hpp
+  ${qst_include_ROOT}/settingsmigrator.hpp
   ${qst_include_ROOT}/startuptab.hpp
   ${qst_include_ROOT}/syncconnector.h
   ${qst_include_ROOT}/syncwebpage.h

--- a/includes/qst/settingsmigrator.hpp
+++ b/includes/qst/settingsmigrator.hpp
@@ -1,0 +1,105 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
+#ifndef settingsmigrator_h
+#define settingsmigrator_h
+#pragma once
+#include <QSettings>
+#include <QString>
+#include <QWindow>
+
+namespace qst
+{
+namespace settings
+{
+
+struct SettingsMigrator
+{
+
+public:
+SettingsMigrator() :
+  mSettings("QSyncthingTray", "qst")
+{
+  validateSettings();
+}
+
+~SettingsMigrator() = default;
+
+//------------------------------------------------------------------------------------//
+
+void validateSettings()
+{
+  QSettings oldSettings("sieren", "QSyncthingTray");
+  oldSettings.setFallbacksEnabled(false);
+  mSettings.setFallbacksEnabled(false);
+  if (oldSettings.childKeys().size() > 1 && mSettings.childKeys().size() == 0)
+  {
+    copySettings(mSettings, oldSettings);
+  }
+  createDefaultSettings();
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void copySettings( QSettings &dst, QSettings &src )
+{
+  QStringList keys = src.allKeys();
+  for( QStringList::iterator i = keys.begin(); i != keys.end(); i++ )
+  {
+    dst.setValue( *i, src.value( *i ) );
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void createDefaultSettings()
+{
+  checkAndSetValue("url", QString("http://127.0.0.1:8384"));
+  checkAndSetValue("monochromeIcon", false);
+  checkAndSetValue("WebZoomFactor", 1.0);
+  checkAndSetValue("ShutdownOnExit", true);
+  checkAndSetValue("notificationsEnabled", true);
+  checkAndSetValue("doSettingsExist", true);
+  checkAndSetValue("launchSyncthingAtStartup", false);
+  checkAndSetValue("animationEnabled", false);
+  checkAndSetValue("pollingInterval", 1.0);
+  checkAndSetValue("apiKey", qst::utilities::readAPIKey());
+  checkAndSetValue("WebWindowSize", QSize(1280, 800));
+}
+
+
+//------------------------------------------------------------------------------------//
+
+template <typename T>
+void checkAndSetValue(QString key, T value)
+{
+  if (mSettings.value(key) == QVariant())
+  {
+    mSettings.setValue(key, value);
+  }
+}
+
+private:
+  QSettings mSettings;
+};
+
+} // settings namespace
+} // qst namespace
+#endif

--- a/includes/qst/window.h
+++ b/includes/qst/window.h
@@ -23,6 +23,7 @@
 #include "processmonitor.hpp"
 #include "startuptab.hpp"
 #include "platforms.hpp"
+#include <qst/settingsmigrator.hpp>
 #include <QDoubleSpinBox>
 #include <QSystemTrayIcon>
 #include <QNetworkAccessManager>
@@ -86,6 +87,7 @@ private slots:
     void quit();
 
 private:
+    qst::settings::SettingsMigrator mSettingsMigrator;
     void createSettingsGroupBox();
     void createActions();
     void createTrayIcon();

--- a/sources/qst/main.cpp
+++ b/sources/qst/main.cpp
@@ -57,8 +57,8 @@ int main(int argc, char *argv[])
 
     label->show();
     qDebug() << text;
-    QCoreApplication::setOrganizationName("sieren");
-    QCoreApplication::setOrganizationDomain("sieren.com");
+    QCoreApplication::setOrganizationName("qst");
+    QCoreApplication::setOrganizationDomain("qst.com");
     QCoreApplication::setApplicationName("QSyncthingTray");
     app.exec();
 }

--- a/sources/qst/processmonitor.cpp
+++ b/sources/qst/processmonitor.cpp
@@ -25,7 +25,7 @@ using namespace qst::monitor;
 
 ProcessMonitor::ProcessMonitor(std::shared_ptr<qst::connector::SyncConnector> pSyncConnector)
   : mpSyncConnector(pSyncConnector)
-  , mSettings("sieren", "QSyncthingTray")
+  , mSettings("QSyncthingTray", "qst")
 {
   loadSettings();
   QLabel *descriptionLabel = new QLabel;

--- a/sources/qst/startuptab.cpp
+++ b/sources/qst/startuptab.cpp
@@ -26,7 +26,7 @@ namespace settings
 
 StartupTab::StartupTab(std::shared_ptr<qst::connector::SyncConnector> pSyncConnector) :
     mpSyncConnector(pSyncConnector)
-  , mSettings("sieren", "QSyncthingTray")
+  , mSettings("QSyncthingTray", "qst")
 {
   
   loadSettings();

--- a/sources/qst/syncconnector.cpp
+++ b/sources/qst/syncconnector.cpp
@@ -36,7 +36,7 @@ namespace connector
 //------------------------------------------------------------------------------------//
 SyncConnector::SyncConnector(QUrl url) :
     mCurrentUrl(url)
-  , mSettings("sieren", "QSyncthingTray")
+  , mSettings("QSyncthingTray", "qst")
 {
   onSettingsChanged();
   connect(

--- a/sources/qst/syncwebview.cpp
+++ b/sources/qst/syncwebview.cpp
@@ -32,7 +32,7 @@ SyncWebView::SyncWebView(QUrl url, Authentication authInfo) :
    mSyncThingUrl(url)
   ,mAuthInfo(authInfo)
   ,mContextMenu(this)
-  ,mSettings("sieren", "QSyncthingTray")
+  ,mSettings("QSyncthingTray", "qst")
 {
   initWebView();
   setupMenu();
@@ -64,8 +64,7 @@ void SyncWebView::initWebView()
 void SyncWebView::pageHasLoaded(bool hasLoaded)
 {
   UNUSED(hasLoaded);
-  QSettings appSettings("sieren", "QSyncthingTray");
-  setZoomFactor(appSettings.value("WebZoomFactor").toDouble());
+  setZoomFactor(mSettings.value("WebZoomFactor").toDouble());
 }
 
 

--- a/sources/qst/window.cpp
+++ b/sources/qst/window.cpp
@@ -55,10 +55,9 @@ Window::Window()
   : mpSyncConnector(new qst::connector::SyncConnector(QUrl(tr("http://127.0.0.1:8384"))))
   , mpProcessMonitor(new qst::monitor::ProcessMonitor(mpSyncConnector))
   , mpStartupTab(new qst::settings::StartupTab(mpSyncConnector))
-  , mSettings("sieren", "QSyncthingTray")
+  , mSettings("QSyncthingTray", "qst")
   , mpAnimatedIconMovie(new QMovie())
 {
-    createDefaultSettings();
     loadSettings();
     createSettingsGroupBox();
 
@@ -696,10 +695,6 @@ void Window::showAuthentication(bool show)
 void Window::loadSettings()
 {
   mCurrentUrl.setUrl(mSettings.value("url").toString());
-  if (mCurrentUrl.toString().length() == 0)
-  {
-    mCurrentUrl.setUrl(tr("http://127.0.0.1:8384"));
-  }
   mCurrentUserPassword = mSettings.value("userpassword").toString().toStdString();
   mCurrentUserName = mSettings.value("username").toString().toStdString();
   mIconMonochrome = mSettings.value("monochromeIcon").toBool();
@@ -708,34 +703,7 @@ void Window::loadSettings()
 }
 
 
-//------------------------------------------------------------------------------------//
 
-void Window::createDefaultSettings()
-{
-  checkAndSetValue("url", tr("http://127.0.0.1:8384"));
-  checkAndSetValue("monochromeIcon", false);
-  checkAndSetValue("WebZoomFactor", 1.0);
-  checkAndSetValue("ShutdownOnExit", true);
-  checkAndSetValue("notificationsEnabled", true);
-  checkAndSetValue("doSettingsExist", true);
-  checkAndSetValue("launchSyncthingAtStartup", false);
-  checkAndSetValue("animationEnabled", false);
-  checkAndSetValue("pollingInterval", 1.0);
-  checkAndSetValue("apiKey", qst::utilities::readAPIKey());
-  checkAndSetValue("WebWindowSize", QSize(1280, 800));
-}
-
-
-//------------------------------------------------------------------------------------//
-
-template <typename T>
-void Window::checkAndSetValue(QString key, T value)
-{
-  if (mSettings.value(key) == QVariant())
-  {
-    mSettings.setValue(key, value);
-  }
-}
 
 //------------------------------------------------------------------------------------//
 


### PR DESCRIPTION
Previously settings would be saved as e.g.
com.sieren.qsyncthingtray or under
~/.config/sieren/ on Linux.

This led to some confusion in users who wanted
to manually edit or delete those files.

Requested:
https://github.com/sieren/QSyncthingTray/issues/125
https://github.com/sieren/QSyncthingTray/issues/123