### PR TITLE
Add default Path to syncthing and inotify

### DIFF
--- a/includes/platforms/darwin/macUtils.hpp
+++ b/includes/platforms/darwin/macUtils.hpp
@@ -96,6 +96,16 @@ namespace darwin
       return{path};
     }
 
+    static auto getDefaultSyncthingLocation() -> QString
+    {
+      return{"/usr/local/bin/syncthing"};
+    }
+
+    static auto getDefaultSyncthingINotifyLocation() -> QString
+    {
+      return{"/usr/local/bin/syncthing-inotify"};
+    }
+
     template<typename U, typename T>
     void doubleClicked(U&& func, T ref)
     {

--- a/includes/platforms/linux/posixUtils.hpp
+++ b/includes/platforms/linux/posixUtils.hpp
@@ -78,6 +78,17 @@ namespace gnu_linux
       return{path};
     }
 
+    
+    static auto getDefaultSyncthingLocation() -> QString
+    {
+      return{"/usr/local/bin/syncthing"};
+    }
+    
+    static auto getDefaultSyncthingINotifyLocation() -> QString
+    {
+      return{"/usr/local/bin/syncthing-inotify"};
+    }
+
     template<typename U, typename T>
     void doubleClicked(U&& func, T ref)
     {

--- a/includes/platforms/windows/winUtils.hpp
+++ b/includes/platforms/windows/winUtils.hpp
@@ -85,6 +85,17 @@ namespace windows
       return{path};
     }
 
+    // No default path on Windows
+    static auto getDefaultSyncthingLocation() -> QString
+    {
+      return{""};
+    }
+    
+    static auto getDefaultSyncthingINotifyLocation() -> QString
+    {
+      return{""};
+    }
+
     template<typename U, typename T>
     void doubleClicked(U&& func, T ref)
     {

--- a/includes/qst/settingsmigrator.hpp
+++ b/includes/qst/settingsmigrator.hpp
@@ -23,6 +23,8 @@
 #include <QString>
 #include <QWindow>
 
+#include <qst/platforms.hpp>
+
 namespace qst
 {
 namespace settings
@@ -82,6 +84,10 @@ void createDefaultSettings()
   checkAndSetValue("pollingInterval", 1.0);
   checkAndSetValue("apiKey", qst::utilities::readAPIKey());
   checkAndSetValue("WebWindowSize", QSize(1280, 800));
+  checkAndSetValue("syncthingpath",
+    sysutils::SystemUtility().getDefaultSyncthingLocation());
+  checkAndSetValue("inotifypath",
+    sysutils::SystemUtility().getDefaultSyncthingINotifyLocation());
 }
 
 


### PR DESCRIPTION
Add platform specific default paths for syncthing
and inotify.

Requested in:
https://github.com/sieren/QSyncthingTray/issues/155