### PR TITLE
Raise Window on subsequent clicks

### DIFF
--- a/sources/qst/syncconnector.cpp
+++ b/sources/qst/syncconnector.cpp
@@ -98,10 +98,12 @@ void SyncConnector::testUrlAvailability()
 
 void SyncConnector::showWebView()
 {
-  if (mpSyncWebView != nullptr)
+  if (mpSyncWebView != nullptr && mpSyncWebView->isVisible())
   {
-    mpSyncWebView->close();
+    mpSyncWebView->raise();
+    return;
   }
+
   mpSyncWebView = std::unique_ptr<webview::WebView>(new webview::WebView(mCurrentUrl,
      mAuthentication));
   connect(mpSyncWebView.get(), &webview::WebView::close, this, &SyncConnector::webViewClosed);


### PR DESCRIPTION
Instead of closing and reloading the UI, we are
making sure it gets raised to foreground if it
exists, else it should load.

As requested: https://github.com/sieren/QSyncthingTray/issues/152