### PR TITLE
Fix HTTPS Check

### DIFF
--- a/includes/qst/syncconnector.h
+++ b/includes/qst/syncconnector.h
@@ -145,7 +145,6 @@ namespace connector
     std::unique_ptr<QTimer> mpConnectionHealthTimer;
     std::unique_ptr<QTimer> mpConnectionAvailabilityTimer;
     std::pair<QString, QString> mAuthentication;
-    std::shared_ptr<SyncConnector> mpSyncConnector;
 
     std::string mSyncthingFilePath;
     QString mINotifyFilePath;

--- a/sources/qst/syncconnector.cpp
+++ b/sources/qst/syncconnector.cpp
@@ -461,7 +461,8 @@ void SyncConnector::ignoreSslErrors(QNetworkReply *reply)
   size_t foundHttp = mCurrentUrl.toString().toStdString().find("http:");
   QVariant statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
 
-  if (statusCode.toInt() == 302) // we're getting redirected, find out if to HTTPS
+  // we're getting redirected, find out if to HTTPS
+  if (statusCode.toInt() == 302 || statusCode.toInt() == 307)
   {
     QVariant url = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
     size_t found = url.toString().toStdString().find("https:");
@@ -477,6 +478,7 @@ void SyncConnector::ignoreSslErrors(QNetworkReply *reply)
       msgBox->setAttribute(Qt::WA_DeleteOnClose);
       msgBox->show();
       msgBox->setFocus();
+      mCurrentUrl = QUrl(mCurrentUrl.toString().replace(tr("http"), tr("https")));
       didShowSSLWarning = true;
     }
   }

--- a/sources/qst/syncwebpage.cpp
+++ b/sources/qst/syncwebpage.cpp
@@ -51,9 +51,8 @@ void SyncWebPage::updateConnInfo(QUrl url, Authentication authInfo)
 //------------------------------------------------------------------------------------//
 
 void SyncWebPage::requireAuthentication(
-  const QUrl &requestUrl, QAuthenticator *authenticator)
+  const QUrl &, QAuthenticator *authenticator)
 {
-UNUSED(requestUrl);
   authenticator->setUser(mAuthInfo.first);
   authenticator->setPassword(mAuthInfo.first);
 }
@@ -61,10 +60,9 @@ UNUSED(requestUrl);
 
 //------------------------------------------------------------------------------------//
 
-auto SyncWebPage::certificateError(const QWebEngineCertificateError &certificateError)
--> bool
+auto SyncWebPage::certificateError(
+  const QWebEngineCertificateError &/*certificateError*/) -> bool
 {
-UNUSED(certificateError);
   return true; // TODO: Figure out whether there is a syncthing CA so we can use the
                // real certificate
 }


### PR DESCRIPTION
This seems to have been broken for a while.
Correctly check for HTTP -> HTTPS forward and display a message in case
the user wrongly uses http despite having opted in for HTTPS in Syncthing.

Adresses: https://github.com/sieren/QSyncthingTray/issues/161 