### PR TITLE
Move Callback to Constructor

### DIFF
--- a/includes/qst/syncconnector.h
+++ b/includes/qst/syncconnector.h
@@ -60,7 +60,7 @@ typedef enum processState
   PAUSED
 } kSyncthingProcessState;
 
-using ConnectionStateCallback = std::function<void(ConnectionState)>;
+using ConnectionStateCallback = std::function<void(ConnectionState&)>;
 
 namespace qst
 {
@@ -71,10 +71,9 @@ namespace connector
   {
     Q_OBJECT
   public:
-    explicit SyncConnector(QUrl url);
+    explicit SyncConnector(QUrl url, ConnectionStateCallback textCallback);
     virtual ~SyncConnector();
-    void setURL(QUrl url, const QString& userName, const QString& password,
-      ConnectionStateCallback setText);
+    void setURL(QUrl url, const QString& userName, const QString& password);
     void showWebView();
     void spawnSyncthingProcess(
       std::string filePath,

--- a/includes/qst/window.h
+++ b/includes/qst/window.h
@@ -85,7 +85,7 @@ private slots:
     void onUpdateIcon();
     void pauseSyncthingClicked(int state);
     void quit();
-
+    void onUpdateConnState(const ConnectionState& result);
 private:
     qst::settings::SettingsMigrator mSettingsMigrator;
     void createSettingsGroupBox();

--- a/includes/qst/window.h
+++ b/includes/qst/window.h
@@ -68,7 +68,7 @@ protected:
     void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
 
 private slots:
-    void updateConnectionHealth(ConnectionHealthStatus status);
+    void updateConnectionHealth(const ConnectionHealthStatus& status);
     void onNetworkActivity(bool activity);
     void setIcon(int index);
     void iconActivated(QSystemTrayIcon::ActivationReason reason);
@@ -94,7 +94,7 @@ private:
     void saveSettings();
     void loadSettings();
     void showAuthentication(bool show);
-    void showMessage(std::string title, std::string body,
+    void showMessage(const std::string& title, const std::string& body,
       QSystemTrayIcon::MessageIcon icon = QSystemTrayIcon::Information);
     void createFoldersMenu();
     void createLastSyncedMenu();

--- a/includes/qst/window.h
+++ b/includes/qst/window.h
@@ -100,7 +100,6 @@ private:
     void createLastSyncedMenu();
     void createDefaultSettings();
     void validateSSLSupport();
-    int getCurrentVersion(std::string reply);
     void onStartAnimation(bool animate);
 
     QTabWidget *mpSettingsTabsWidget;

--- a/sources/qst/syncconnector.cpp
+++ b/sources/qst/syncconnector.cpp
@@ -34,8 +34,9 @@ namespace connector
 
 //------------------------------------------------------------------------------------//
 //------------------------------------------------------------------------------------//
-SyncConnector::SyncConnector(QUrl url) :
-    mCurrentUrl(url)
+SyncConnector::SyncConnector(QUrl url, ConnectionStateCallback textCallback) :
+    mConnectionStateCallback(textCallback)
+  , mCurrentUrl(url)
   , mSettings("QSyncthingTray", "qst")
 {
   onSettingsChanged();
@@ -60,7 +61,7 @@ SyncConnector::SyncConnector(QUrl url) :
 //------------------------------------------------------------------------------------//
 
 void SyncConnector::setURL(QUrl url, const QString& username, const
-  QString& password, ConnectionStateCallback setText)
+  QString& password)
 {
   if (username.isEmpty() == false && password.isEmpty() == false)
   {
@@ -69,7 +70,6 @@ void SyncConnector::setURL(QUrl url, const QString& username, const
     url.setPassword(mAuthentication.second);
   }
   mCurrentUrl = url;
-  mConnectionStateCallback = setText;
   testUrlAvailability();
 }
 
@@ -145,10 +145,8 @@ void SyncConnector::urlTested(QNetworkReply* reply)
         std::unique_ptr<api::APIHandlerBase>(
           api::APIHandlerFactory<QNetworkReply>().getAPIForVersion(versionNumber));
     }
-    if (mConnectionStateCallback != nullptr)
-    {
-      mConnectionStateCallback(connectionInfo);
-    }
+
+    mConnectionStateCallback(connectionInfo);
     mpConnectionAvailabilityTimer->stop();
     mpConnectionHealthTimer->start(mConnectionHealthTime);
     checkAndSpawnINotifyProcess(false);
@@ -316,7 +314,7 @@ void SyncConnector::pauseSyncthing(bool paused)
     spawnSyncthingProcess(mSyncthingFilePath, true);
     checkAndSpawnINotifyProcess(false);
     setURL(mCurrentUrl, mCurrentUrl.userName(),
-     mCurrentUrl.password(), mConnectionStateCallback);
+     mCurrentUrl.password());
   }
 }
 

--- a/sources/qst/window.cpp
+++ b/sources/qst/window.cpp
@@ -120,7 +120,7 @@ Window::Window()
 
 //------------------------------------------------------------------------------------//
 
-void Window::setVisible(bool visible)
+void Window::setVisible(const bool visible)
 {
   QDialog::setVisible(visible);
   qst::sysutils::SystemUtility().showDockIcon(visible);
@@ -163,7 +163,7 @@ void Window::onUpdateConnState(const ConnectionState& result)
 
 //------------------------------------------------------------------------------------//
 
-void Window::setIcon(int index)
+void Window::setIcon(const int index)
 {
   // temporary workaround as setIcon seems to leak memory
   // https://bugreports.qt.io/browse/QTBUG-23658?jql=text%20~%20%22setIcon%20memory%22
@@ -221,7 +221,7 @@ void Window::testURL()
 
 //------------------------------------------------------------------------------------//
 
-void Window::updateConnectionHealth(ConnectionHealthStatus status)
+void Window::updateConnectionHealth(const ConnectionHealthStatus& status)
 {
   if (mpProcessMonitor->isPausingProcessRunning())
   {
@@ -289,7 +289,7 @@ void Window::updateConnectionHealth(ConnectionHealthStatus status)
 
 //------------------------------------------------------------------------------------//
 
-void Window::onNetworkActivity(bool activity)
+void Window::onNetworkActivity(const bool activity)
 {
   onStartAnimation(activity);
 }
@@ -297,7 +297,7 @@ void Window::onNetworkActivity(bool activity)
 
 //------------------------------------------------------------------------------------//
 
-void Window::monoChromeIconChanged(int state)
+void Window::monoChromeIconChanged(const int state)
 {
   mIconMonochrome = state == 2 ? true : false;
   mSettings.setValue("monochromeIcon", mIconMonochrome);
@@ -306,7 +306,7 @@ void Window::monoChromeIconChanged(int state)
 
 //------------------------------------------------------------------------------------//
 
-void Window::pauseSyncthingClicked(int state)
+void Window::pauseSyncthingClicked(const int state)
 {
   mpSyncConnector->pauseSyncthing(state == 1);
 }
@@ -314,7 +314,7 @@ void Window::pauseSyncthingClicked(int state)
 
 //------------------------------------------------------------------------------------//
 
-void Window::animateIconBoxChanged(int state)
+void Window::animateIconBoxChanged(const int state)
 {
   mShouldAnimateIcon = state == Qt::CheckState::Checked ? true : false;
   mSettings.setValue("animationEnabled", mShouldAnimateIcon);
@@ -323,7 +323,7 @@ void Window::animateIconBoxChanged(int state)
 
 //------------------------------------------------------------------------------------//
 
-void Window::iconActivated(QSystemTrayIcon::ActivationReason reason)
+void Window::iconActivated(const QSystemTrayIcon::ActivationReason reason)
 {
   switch (reason)
   {
@@ -349,7 +349,7 @@ void Window::showWebView()
 
 //------------------------------------------------------------------------------------//
 
-void Window::authCheckBoxChanged(int state)
+void Window::authCheckBoxChanged(const int state)
 {
   if (state)
   {
@@ -364,7 +364,7 @@ void Window::authCheckBoxChanged(int state)
 
 //------------------------------------------------------------------------------------//
 
-void Window::webViewZoomFactorChanged(double value)
+void Window::webViewZoomFactorChanged(const double value)
 {
   if (mpSyncConnector->getWebView())
   {
@@ -376,8 +376,8 @@ void Window::webViewZoomFactorChanged(double value)
 
 //------------------------------------------------------------------------------------//
 
-void Window::showMessage(std::string title, std::string body,
-  QSystemTrayIcon::MessageIcon icon)
+void Window::showMessage(const std::string& title, const std::string& body,
+  const QSystemTrayIcon::MessageIcon icon)
 {
   if (mNotificationsEnabled)
   {
@@ -694,7 +694,7 @@ void Window::saveSettings()
 
 //------------------------------------------------------------------------------------//
 
-void Window::showAuthentication(bool show)
+void Window::showAuthentication(const bool show)
 {
   if (show)
   {
@@ -745,7 +745,7 @@ void Window::validateSSLSupport()
 
 //------------------------------------------------------------------------------------//
 
-void Window::onStartAnimation(bool animate)
+void Window::onStartAnimation(const bool animate)
 {
   QString iconToAnimate = mIconMonochrome ? tr(kAnimatedIconSet.back().c_str())
     : tr(kAnimatedIconSet.front().c_str());


### PR DESCRIPTION
Move `ConnectionStateCallback` to constructor so we can get rid off `nullptr` checks.