### PR TITLE
Add Update Notification

### DIFF
--- a/includes/CMakeLists.txt
+++ b/includes/CMakeLists.txt
@@ -16,6 +16,7 @@ set(qst_HEADERS
   ${qst_include_ROOT}/settingsmigrator.hpp
   ${qst_include_ROOT}/startuptab.hpp
   ${qst_include_ROOT}/syncconnector.h
+  ${qst_include_ROOT}/updatenotifier.h
   ${qst_include_ROOT}/utilities.hpp
   ${qst_include_ROOT}/webview.h
   ${qst_include_ROOT}/window.h

--- a/includes/qst/settingsmigrator.hpp
+++ b/includes/qst/settingsmigrator.hpp
@@ -19,6 +19,7 @@
 #ifndef settingsmigrator_h
 #define settingsmigrator_h
 #pragma once
+#include <QDateTime>
 #include <QSettings>
 #include <QString>
 #include <QWindow>
@@ -88,6 +89,8 @@ void createDefaultSettings()
     sysutils::SystemUtility().getDefaultSyncthingLocation());
   checkAndSetValue("inotifypath",
     sysutils::SystemUtility().getDefaultSyncthingINotifyLocation());
+  checkAndSetValue("lastupdatecheck", QDateTime().currentDateTime());
+  checkAndSetValue("lastshownupdatenotification", QString("0"));
 }
 
 

--- a/includes/qst/updatenotifier.h
+++ b/includes/qst/updatenotifier.h
@@ -1,0 +1,73 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
+#ifndef UPDATENOTIFIER_H
+#define UPDATENOTIFIER_H
+
+#include <QNetworkAccessManager>
+#include <QObject>
+#include <QSettings>
+#include <QTimer>
+#include <functional>
+
+//------------------------------------------------------------------------------------//
+
+static const QString kGithubUrl =
+  "https://api.github.com/repos/sieren/QSyncthingTray/releases/latest";
+static const double kUpdateInterval = 604800000; // 7 days
+static const QString kTagKey = "tag_name";
+
+//------------------------------------------------------------------------------------//
+using NotificationCallback = std::function<void(bool)>;
+//------------------------------------------------------------------------------------//
+
+namespace qst
+{
+namespace update
+{
+  class UpdateNotifier : QObject
+{
+  Q_OBJECT
+public:
+  UpdateNotifier(NotificationCallback callback, const QString& currentVer);
+  ~UpdateNotifier() = default;
+  UpdateNotifier(UpdateNotifier&&) = delete;
+  UpdateNotifier(const UpdateNotifier&) = delete;
+  UpdateNotifier& operator=(const UpdateNotifier&) = delete;
+
+public slots:
+  void checkUpdate(const bool manualCheck = false);
+
+private slots:
+  void netRequestFinished(QNetworkReply* reply);
+
+private:
+  NotificationCallback mNotifyCallback;
+  bool mDidCheckManually = false;
+  void performNetRequest();
+  QSettings mSettings;
+  QString mCurrentVer;
+
+  QTimer mUpdateCheckTimer;
+  QNetworkAccessManager network;
+};
+
+} // update namespace
+} // qst namespace
+
+#endif

--- a/includes/qst/window.h
+++ b/includes/qst/window.h
@@ -24,6 +24,7 @@
 #include "startuptab.hpp"
 #include "platforms.hpp"
 #include <qst/settingsmigrator.hpp>
+#include <qst/updatenotifier.h>
 #include <QDoubleSpinBox>
 #include <QSystemTrayIcon>
 #include <QNetworkAccessManager>
@@ -86,6 +87,7 @@ private slots:
     void pauseSyncthingClicked(int state);
     void quit();
     void onUpdateConnState(const ConnectionState& result);
+    void checkForUpdate();
 private:
     qst::settings::SettingsMigrator mSettingsMigrator;
     void createSettingsGroupBox();
@@ -135,6 +137,7 @@ private:
     QAction *mpShowWebViewAction;
     QAction *mpPreferencesAction;
     QAction *mpShowGitHubAction;
+    QAction *mpCheckUpdateAction;
     QAction *mpPauseSyncthingAction;
     QAction *mpQuitAction;
 
@@ -165,6 +168,9 @@ private:
     bool mShouldAnimateIcon;
     bool mShouldStopAnimation;
     int mLastConnectionState;
+
+    qst::update::UpdateNotifier mUpdateNotifier;
+    void onUpdateCheck(const bool isNewVersion);
 
     template <typename T>
     void checkAndSetValue(QString key, T value);

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -8,6 +8,7 @@ set(qst_SOURCES
   ${qst_src_ROOT}/processmonitor.cpp
   ${qst_src_ROOT}/startuptab.cpp
   ${qst_src_ROOT}/syncconnector.cpp
+  ${qst_src_ROOT}/updatenotifier.cpp
   ${qst_src_ROOT}/window.cpp
 )
 

--- a/sources/qst/updatenotifier.cpp
+++ b/sources/qst/updatenotifier.cpp
@@ -1,0 +1,122 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
+
+#include <qst/updatenotifier.h>
+#include <QContextMenuEvent>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QTimer>
+#include <functional>
+#include <iostream>
+
+//------------------------------------------------------------------------------------//
+
+namespace qst
+{
+namespace update
+{
+
+//------------------------------------------------------------------------------------//
+
+UpdateNotifier::UpdateNotifier(NotificationCallback callback,
+  const QString& currentVer) :
+    mNotifyCallback(callback)
+  , mSettings("QSyncthingTray", "qst")
+  , mCurrentVer(currentVer)
+{
+  connect(
+    &network, SIGNAL (finished(QNetworkReply*)),
+    this, SLOT (netRequestFinished(QNetworkReply*))
+    );
+  connect(&mUpdateCheckTimer, SIGNAL(timeout()), this,
+    SLOT(checkUpdate()));
+  mUpdateCheckTimer.start(30000);
+}
+
+//------------------------------------------------------------------------------------//
+
+void UpdateNotifier::checkUpdate(const bool manualCheck)
+{
+  mDidCheckManually = manualCheck;
+  if (!mDidCheckManually)
+  {
+    auto lastUpdate = mSettings.value("lastupdatecheck").toDateTime();
+    auto timeDiff = lastUpdate.msecsTo(QDateTime().currentDateTime());
+    if (timeDiff > kUpdateInterval)
+    {
+      performNetRequest();
+    }
+  }
+  else
+  {
+    performNetRequest();
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void UpdateNotifier::performNetRequest()
+{
+  QUrl url(kGithubUrl);
+  QNetworkRequest request(url);
+  network.clearAccessCache();
+  network.get(request);
+  mSettings.setValue("lastupdatecheck", QDateTime().currentDateTime());
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void UpdateNotifier::netRequestFinished(QNetworkReply* reply)
+{
+  QByteArray replyData;
+  if (reply->error() == QNetworkReply::NoError)
+  {
+    replyData = reply->readAll();
+  }
+  else
+  {
+    return;
+  }
+  QString data = static_cast<QString>(replyData);
+  QJsonDocument replyDoc = QJsonDocument::fromJson(data.toUtf8());
+  QJsonObject replyObj = replyDoc.object();
+
+  auto lastKey = replyObj.find(kTagKey).value().toString();
+  auto lastShownForVersion = mSettings.value("lastshownupdatenotification").toString();
+  if (lastKey != mCurrentVer && lastKey != lastShownForVersion)
+  {
+    mNotifyCallback(true);
+    mSettings.setValue("lastshownupdatenotification", lastKey);
+    return;
+  }
+  else if (mDidCheckManually)
+  {
+    mNotifyCallback(!(lastKey == mCurrentVer));
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+} // update namespace
+} // qst namespace

--- a/sources/qst/window.cpp
+++ b/sources/qst/window.cpp
@@ -42,7 +42,7 @@
 
 
 //! Layout
-#define currentVersion "v0.5.2"
+#define currentVersion "0.5.2"
 #define maximumWidth 400
 static const std::list<std::pair<std::string, std::string>> kIconSet(
   {{":/images/syncthingBlue.png", ":/images/syncthingGrey.png"},
@@ -61,6 +61,8 @@ Window::Window()
   , mpStartupTab(new qst::settings::StartupTab(mpSyncConnector))
   , mSettings("QSyncthingTray", "qst")
   , mpAnimatedIconMovie(new QMovie())
+  , mUpdateNotifier(std::bind(&Window::onUpdateCheck, this, std::placeholders::_1),
+      QString(tr(currentVersion)))
 {
     loadSettings();
     createSettingsGroupBox();
@@ -569,6 +571,9 @@ void Window::createActions()
   mpShowGitHubAction = new QAction(tr("About"), this);
   connect(mpShowGitHubAction, SIGNAL(triggered()), this, SLOT(showAboutPage()));
 
+  mpCheckUpdateAction = new QAction(tr("Check for Update"), this);
+  connect(mpCheckUpdateAction, SIGNAL(triggered()), this, SLOT(checkForUpdate()));
+
   mpQuitAction = new QAction(tr("&Quit"), this);
   connect(mpQuitAction, SIGNAL(triggered()), qApp, SLOT(quit()));
 }
@@ -664,6 +669,7 @@ void Window::createTrayIcon()
   mpTrayIconMenu->addAction(mpPreferencesAction);
   mpTrayIconMenu->addSeparator();
   mpTrayIconMenu->addAction(mpShowGitHubAction);
+  mpTrayIconMenu->addAction(mpCheckUpdateAction);
   mpTrayIconMenu->addSeparator();
   mpTrayIconMenu->addAction(mpQuitAction);
   if (mpTrayIcon == nullptr)
@@ -783,10 +789,44 @@ void Window::showAboutPage()
   QMessageBox msgBox(this);
   msgBox.setWindowTitle("About QSyncthingTray");
   msgBox.setTextFormat(Qt::RichText);
-  msgBox.setText("<p align='center'>" currentVersion " (c) 2015 The QSyncthingTray " \
+  msgBox.setText("<p align='center'> v" currentVersion " (c) 2015 The QSyncthingTray " \
     "Authors. <br/> This program comes with absolutely no warranty. <br/><br/>" \
     "For more visit <a href='http://www.github.com/sieren/qsyncthingtray/'>" \
     "QSyncthingTray on Github</a></p>");
+  msgBox.exec();
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void Window::checkForUpdate()
+{
+  mUpdateNotifier.checkUpdate(true);
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void Window::onUpdateCheck(const bool isNewVersion)
+{
+  QMessageBox msgBox(this);
+  if (isNewVersion)
+  {
+    msgBox.setWindowTitle("QSyncthingTray Update");
+    msgBox.setTextFormat(Qt::RichText);
+    msgBox.setText("<p align='center'><b> Update Available</b> <br/><br/>" \
+                   "A new version of QSyncthingTray is available. <br/>" \
+                   "For more visit <a href='http://www.github.com/sieren/qsyncthingtray/'>" \
+                   "QSyncthingTray on Github</a></p>");
+  }
+  else
+  {
+    msgBox.setWindowTitle("QSyncthingTray Update");
+    msgBox.setTextFormat(Qt::RichText);
+    msgBox.setText("<p align='center'><b>No new update available</b> <br/><br/>" \
+                   "For more visit <a href='http://www.github.com/sieren/qsyncthingtray/'>" \
+                   "QSyncthingTray on Github</a></p>");
+  }
   msgBox.exec();
 }
 


### PR DESCRIPTION
Add an Update notification which will check for a new
version through the Github API every 7 days.

Additionally a manual check can be performed through
a new menu entry.

Notifications will only be displayed once.

Issue: https://github.com/sieren/QSyncthingTray/issues/42#issuecomment-250978944