### PR TITLE
Move GIFs to separate QRC files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,10 @@ source_group("Platforms" ${qst_platform_SOURCES})
 #
 
 # qt5_wrap_ui(UI_HEADERS mainwindow.ui)
-qt5_add_resources(UI_RESOURCES resources/qsyncthing.qrc)
+qt5_add_resources(UI_RESOURCES
+  resources/qsyncthing.qrc
+  resources/qsyncthingblueanim.qrc
+  resources/qsyncthingdarkanim.qrc)
 
 include_directories(includes)
 add_subdirectory(includes)

--- a/resources/qsyncthing.qrc
+++ b/resources/qsyncthing.qrc
@@ -1,7 +1,5 @@
 <RCC>
     <qresource prefix="/">
-        <file>images/syncthingBlueAnim.gif</file>
-        <file>images/syncthingBlackAnim.gif</file>
         <file>images/syncthingBlue.png</file>
         <file>images/syncthingGrey.png</file>
         <file>images/Syncthing.icns</file>

--- a/resources/qsyncthingblueanim.qrc
+++ b/resources/qsyncthingblueanim.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>images/syncthingBlueAnim.gif</file>
+    </qresource>
+</RCC>

--- a/resources/qsyncthingdarkanim.qrc
+++ b/resources/qsyncthingdarkanim.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>images/syncthingBlackAnim.gif</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
This is an attempt to remove compile time memory usage
by splitting out the larger GIF files into separate
qrc files.

Attempt to fix: https://github.com/sieren/QSyncthingTray/issues/162