### PR TITLE
0.5.6 Fixes

### DIFF
--- a/QSyncthingTray.pro
+++ b/QSyncthingTray.pro
@@ -24,7 +24,9 @@ SOURCES       = sources/qst/main.cpp \
                 sources/qst/updatenotifier.cpp \
                 sources/contrib/qcustomplot.cpp
 RESOURCES     = \
-                resources/qsyncthing.qrc
+                resources/qsyncthing.qrc \
+                resources/qsyncthingblueanim.qrc \
+                resources/qsyncthingdarkanim.qrc
 
 QT += widgets
 QT += network

--- a/includes/qst/window.h
+++ b/includes/qst/window.h
@@ -72,7 +72,7 @@ protected:
 private slots:
     void updateConnectionHealth(const ConnectionStateData& state);
     void onNetworkActivity(bool activity);
-    void setIcon(int index);
+    void setIcon(int index, const bool isManualSet = false);
     void iconActivated(QSystemTrayIcon::ActivationReason reason);
     void showWebView();
     void messageClicked();

--- a/sources/qst/syncconnector.cpp
+++ b/sources/qst/syncconnector.cpp
@@ -267,7 +267,7 @@ void SyncConnector::connectionHealthReceived(QNetworkReply* reply)
   auto result = mAPIHandler->getConnections(replyData);
   auto traffic = mAPIHandler->getCurrentTraffic(replyData);
 
-  emit(onNetworkActivityChanged(std::get<1>(traffic) + std::get<1>(traffic) > kNetworkNoiseFloor));
+  emit(onNetworkActivityChanged(std::get<0>(traffic) + std::get<1>(traffic) > kNetworkNoiseFloor));
   emit(onConnectionHealthChanged({result, traffic}));
 
   reply->deleteLater();

--- a/sources/qst/window.cpp
+++ b/sources/qst/window.cpp
@@ -165,13 +165,13 @@ void Window::onUpdateConnState(const ConnectionState& result)
 
 //------------------------------------------------------------------------------------//
 
-void Window::setIcon(const int index)
+void Window::setIcon(const int index, const bool isManualSet)
 {
   // temporary workaround as setIcon seems to leak memory
   // https://bugreports.qt.io/browse/QTBUG-23658?jql=text%20~%20%22setIcon%20memory%22
   // https://bugreports.qt.io/browse/QTBUG-16113?jql=text%20~%20%22setIcon%20memory%22
 
-  if (index != mLastIconIndex)
+  if (index != mLastIconIndex || isManualSet)
   {
     QIcon icon;
     std::pair<std::string, std::string> iconSet = mIconMonochrome ?
@@ -314,6 +314,7 @@ void Window::monoChromeIconChanged(const int state)
 {
   mIconMonochrome = state == 2 ? true : false;
   mSettings.setValue("monochromeIcon", mIconMonochrome);
+  setIcon(mLastIconIndex, true);
 }
 
 

--- a/sources/qst/window.cpp
+++ b/sources/qst/window.cpp
@@ -42,7 +42,7 @@
 
 
 //! Layout
-#define currentVersion "0.5.5rc2"
+#define currentVersion "0.5.6"
 #define maximumWidth 400
 static const std::list<std::pair<std::string, std::string>> kIconSet(
   {{":/images/syncthingBlue.png", ":/images/syncthingGrey.png"},


### PR DESCRIPTION
Fixes an issue with mutex acquisition in Statistics.
Fixes an issue with updating the Icon from the Settings to Monochrome/Color.
Fixes an issue with missing animations on Windows.

https://github.com/sieren/QSyncthingTray/issues/178