### PR TITLE
Fix Standby Issues

### DIFF
--- a/includes/CMakeLists.txt
+++ b/includes/CMakeLists.txt
@@ -16,6 +16,7 @@ set(qst_HEADERS
   ${qst_include_ROOT}/appsettings.hpp
   ${qst_include_ROOT}/identifiers.hpp
   ${qst_include_ROOT}/platforms.hpp
+  ${qst_include_ROOT}/processcontroller.h
   ${qst_include_ROOT}/processmonitor.hpp
   ${qst_include_ROOT}/settingsmigrator.hpp
   ${qst_include_ROOT}/startuptab.hpp

--- a/includes/qst/processcontroller.h
+++ b/includes/qst/processcontroller.h
@@ -1,0 +1,84 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
+#ifndef processcontroller_h
+#define processcontroller_h
+#include <QObject>
+#include <QProcess>
+#include <QSettings>
+#include <map>
+#include <memory>
+#include <qst/appsettings.hpp>
+
+enum class ProcessState
+{
+  SPAWNED,
+  NOT_RUNNING,
+  ALREADY_RUNNING,
+  PAUSED
+};
+
+using ProcessStateInfo = std::map<std::string, ProcessState>;
+
+namespace
+{
+  static const std::string kSyncthingIdentifier{"syncthing"};
+  static const std::string kNotifyIdentifier{"inotify"};
+} // anon namespace
+
+namespace qst
+{
+namespace process
+{
+
+class ProcessController : public QObject
+{
+  Q_OBJECT
+public:
+  ProcessController(std::shared_ptr<settings::AppSettings> appSettings);
+  ProcessController(ProcessController&&) = delete;
+  ProcessController(const ProcessController&) = delete;
+  ProcessController& operator=(const ProcessController&) = delete;
+  ~ProcessController();
+  void setPaused(const bool paused);
+  void checkAndSpawnINotifyProcess();
+
+signals:
+  void onNothing(int bla);
+  void onProcessSpawned(ProcessStateInfo procState);
+
+private slots:
+  void syncThingProcessSpawned(QProcess::ProcessState newState);
+  void notifyProcessSpawned(QProcess::ProcessState newState);
+  void onSettingsUpdated();
+
+private:
+  void spawnSyncthingProcess();
+  void spawnINotifyProcess();
+  void killProcesses();
+  void shutdownINotifyProcess();
+  qst::sysutils::SystemUtility mSystemUtil;
+  std::shared_ptr<settings::AppSettings> mpAppSettings;
+  std::unique_ptr<QProcess> mpSyncthingProcess;
+  std::unique_ptr<QProcess> mpINotifyProcess;
+};
+
+} // process namespace
+} // qst namespace
+
+#endif /* processcontroller_h */

--- a/includes/qst/startuptab.hpp
+++ b/includes/qst/startuptab.hpp
@@ -41,6 +41,8 @@
 #include <iostream>
 #include <map>
 #include <qst/appsettings.hpp>
+#include <qst/processcontroller.h>
+#include <qst/processmonitor.hpp>
 #include "syncconnector.h"
 
 QT_BEGIN_NAMESPACE
@@ -66,11 +68,9 @@ class StartupTab : public QWidget
   Q_OBJECT
   
 public:
-  StartupTab(std::shared_ptr<qst::connector::SyncConnector> pSyncConnector,
+  StartupTab(std::shared_ptr<process::ProcessController> pProcController,
     std::shared_ptr<settings::AppSettings> appSettings);
   ~StartupTab();
-  bool isPausingProcessRunning();
-  void spawnSyncthingApp();
 
 public slots:
   void saveSettings();
@@ -88,6 +88,7 @@ private:
   void startProcesses();
   void loadSettings();
   void initGUI();
+  void displayPathNotFound(const QString& processName);
   template <typename T, typename ... TArgs>
   void hideShowElements(bool show, T uiElement, TArgs... Elements);
 
@@ -113,7 +114,7 @@ private:
   QString mCurrentSyncthingPath;
   QString mCurrentINotifyPath;
 
-  std::shared_ptr<qst::connector::SyncConnector> mpSyncConnector;
+  std::shared_ptr<process::ProcessController> mpProcController;
   qst::sysutils::SystemUtility systemUtil;
   std::shared_ptr<settings::AppSettings> mpAppSettings;
 };

--- a/includes/qst/syncconnector.h
+++ b/includes/qst/syncconnector.h
@@ -92,6 +92,7 @@ namespace connector
   private:
     void ignoreSslErrors(QNetworkReply *reply);
     void getCurrentConfig();
+    void resetNetworkAccessManager();
     bool checkIfFileExists(QString path);
     void urlTested(QNetworkReply* reply);
     void connectionHealthReceived(QNetworkReply* reply);
@@ -109,7 +110,7 @@ namespace connector
 
     //! Network access, new methods should be added here
     //! so the called function can dispatch accordingly
-    QNetworkAccessManager network;
+    QSharedPointer<QNetworkAccessManager> mpNetwork;
     enum class kRequestMethod {
       urlTested,
       connectionHealth,

--- a/includes/qst/utilities.hpp
+++ b/includes/qst/utilities.hpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <tuple>
 #include <QFile>
+#include <QFileInfo>
 #include <QXmlStreamReader>
 #include "platforms.hpp"
 
@@ -166,6 +167,23 @@ static QString trafficToString(T traffic)
   to_string_with_precision(traffic/kBytesToKilobytes, 2) + " MB/s" :
   to_string_with_precision(traffic, 2) + " KB/s";
   return QString(strTraffic.c_str());
+}
+
+
+//------------------------------------------------------------------------------------//
+
+static auto checkIfFileExists(QString path) -> bool
+{
+  QFileInfo checkFile(path);
+  // check if file exists and if yes: Is it really a file and not a directory?
+  if (checkFile.exists() && checkFile.isFile())
+  {
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 

--- a/includes/qst/window.h
+++ b/includes/qst/window.h
@@ -24,6 +24,7 @@
 #include "startuptab.hpp"
 #include "platforms.hpp"
 #include <qst/appsettings.hpp>
+#include <qst/processcontroller.h>
 #include <qst/statswidget.h>
 #include <qst/updatenotifier.h>
 #include <QDoubleSpinBox>
@@ -161,6 +162,7 @@ private:
     QString mCurrentUserName;
     QString mCurrentUserPassword;
     std::shared_ptr<qst::settings::AppSettings> mpAppSettings;
+    std::shared_ptr<qst::process::ProcessController> mpProcController;
     std::shared_ptr<qst::connector::SyncConnector> mpSyncConnector;
     std::unique_ptr<qst::monitor::ProcessMonitor> mpProcessMonitor;
     std::unique_ptr<qst::settings::StartupTab> mpStartupTab;

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -7,6 +7,7 @@ set(platforms_src_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/platforms)
 
 set(qst_SOURCES
   ${qst_src_ROOT}/main.cpp
+  ${qst_src_ROOT}/processcontroller.cpp
   ${qst_src_ROOT}/processmonitor.cpp
   ${qst_src_ROOT}/startuptab.cpp
   ${qst_src_ROOT}/statswidget.cpp

--- a/sources/qst/processcontroller.cpp
+++ b/sources/qst/processcontroller.cpp
@@ -1,0 +1,232 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+//------------------------------------------------------------------------------------//
+
+#include <qst/processcontroller.h>
+#include <QDir>
+
+//------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------//
+
+namespace qst
+{
+namespace process
+{
+
+
+//------------------------------------------------------------------------------------//
+
+ProcessController::ProcessController(std::shared_ptr<settings::AppSettings> appSettings) :
+  mpAppSettings(appSettings)
+{
+  connect(mpAppSettings.get(), &settings::AppSettings::settingsUpdated,
+    this, &ProcessController::onSettingsUpdated);
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void ProcessController::syncThingProcessSpawned(QProcess::ProcessState newState)
+{
+  switch (newState)
+  {
+    case QProcess::Running:
+      emit(onProcessSpawned({{kSyncthingIdentifier, ProcessState::SPAWNED}}));
+      break;
+    case QProcess::NotRunning:
+      emit(onProcessSpawned({{kSyncthingIdentifier, ProcessState::NOT_RUNNING}}));
+      break;
+    default:
+      emit(onProcessSpawned({{kSyncthingIdentifier, ProcessState::NOT_RUNNING}}));
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void ProcessController::checkAndSpawnINotifyProcess()
+{
+  if (mpINotifyProcess)
+  {
+    mpINotifyProcess->terminate();
+  }
+  if (mpAppSettings->value(kLaunchInotifyStartupId).toBool())
+  {
+    const QString filepath = mpAppSettings->value(kInotifyPathId).toString();
+    if (!mSystemUtil.isBinaryRunning(std::string("syncthing-inotify")))
+    {
+      mpINotifyProcess = std::unique_ptr<QProcess>(new QProcess(this));
+      QString processPath = QDir::toNativeSeparators(filepath);
+      connect(mpINotifyProcess.get(), SIGNAL(stateChanged(QProcess::ProcessState)),
+              this, SLOT(notifyProcessSpawned(QProcess::ProcessState)));
+      mpINotifyProcess->start(processPath, QStringList(), QIODevice::Unbuffered);
+    }
+    else
+    {
+      emit(onProcessSpawned({{kNotifyIdentifier, ProcessState::ALREADY_RUNNING}}));
+    }
+  }
+  else
+  {
+    shutdownINotifyProcess();
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void ProcessController::notifyProcessSpawned(QProcess::ProcessState newState)
+{
+  switch (newState)
+  {
+    case QProcess::Running:
+      emit(onProcessSpawned({{kNotifyIdentifier, ProcessState::SPAWNED}}));
+      break;
+    case QProcess::NotRunning:
+      emit(onProcessSpawned({{kNotifyIdentifier, ProcessState::NOT_RUNNING}}));
+      break;
+    default:
+      emit(onProcessSpawned({{kNotifyIdentifier, ProcessState::NOT_RUNNING}}));
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void ProcessController::setPaused(const bool paused)
+{
+  if (paused)
+  {
+    shutdownINotifyProcess();
+    emit(onProcessSpawned({{kSyncthingIdentifier, ProcessState::PAUSED}}));
+    if (mpAppSettings->value(kLaunchInotifyStartupId).toBool())
+    {
+      emit(onProcessSpawned({{kNotifyIdentifier, ProcessState::PAUSED}}));
+    }
+  }
+  else
+  {
+    spawnSyncthingProcess();
+    spawnINotifyProcess();
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void ProcessController::onSettingsUpdated()
+{
+  spawnSyncthingProcess();
+  spawnINotifyProcess();
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void ProcessController::spawnSyncthingProcess()
+{
+  QString syncthingFilePath = mpAppSettings->value(kSyncthingPathId).toString();
+  if (mpAppSettings->value(kLaunchSyncthingStartupId).toBool())
+  {
+    if (!mSystemUtil.isBinaryRunning(std::string("syncthing")))
+    {
+      mpSyncthingProcess = std::unique_ptr<QProcess>(new QProcess(this));
+      connect(mpSyncthingProcess.get(), SIGNAL(stateChanged(QProcess::ProcessState)),
+              this, SLOT(syncThingProcessSpawned(QProcess::ProcessState)));
+      QString processPath = QDir::toNativeSeparators(syncthingFilePath);
+      QStringList launchArgs;
+      launchArgs << "-no-browser";
+      mpSyncthingProcess->start(processPath, launchArgs);
+    }
+    else
+    {
+      emit(onProcessSpawned({{kSyncthingIdentifier, ProcessState::ALREADY_RUNNING}}));
+    }
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void ProcessController::spawnINotifyProcess()
+{
+  if (mpAppSettings->value(kLaunchInotifyStartupId).toBool())
+  {
+    if (!mSystemUtil.isBinaryRunning(std::string("syncthing-inotify")))
+    {
+      mpINotifyProcess = std::unique_ptr<QProcess>(new QProcess(this));
+      QString processPath = QDir::toNativeSeparators(
+         mpAppSettings->value(kInotifyPathId).toString());
+      connect(mpINotifyProcess.get(), SIGNAL(stateChanged(QProcess::ProcessState)),
+              this, SLOT(notifyProcessSpawned(QProcess::ProcessState)));
+      mpINotifyProcess->start(processPath, QStringList(), QIODevice::Unbuffered);
+    }
+    else
+    {
+      emit(onProcessSpawned({{kNotifyIdentifier, ProcessState::ALREADY_RUNNING}}));
+    }
+  }
+  else
+  {
+    shutdownINotifyProcess();
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void ProcessController::shutdownINotifyProcess()
+{
+  if (mpINotifyProcess != nullptr &&
+      mpINotifyProcess->state() == QProcess::Running)
+  {
+    mpINotifyProcess->kill();
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+ProcessController::~ProcessController()
+{
+  killProcesses();
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void ProcessController::killProcesses()
+{
+  if (mpSyncthingProcess != nullptr
+      && mpAppSettings->value("ShutdownOnExit").toBool())
+  {
+    mpSyncthingProcess->waitForFinished();
+  }
+  if (mpINotifyProcess != nullptr
+      && mpINotifyProcess->state() == QProcess::Running)
+  {
+    mpINotifyProcess->terminate();
+    mpINotifyProcess->waitForFinished();
+  }
+}
+
+//------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------//
+
+} // process namespace
+} // qst namespace

--- a/sources/qst/window.cpp
+++ b/sources/qst/window.cpp
@@ -56,10 +56,11 @@ static const std::list<std::string> kAnimatedIconSet(
 Window::Window()
   :
     mpAppSettings(new qst::settings::AppSettings())
+  , mpProcController(new qst::process::ProcessController(mpAppSettings))
   , mpSyncConnector(new qst::connector::SyncConnector(QUrl(tr("http://127.0.0.1:8384")),
       std::bind(&Window::onUpdateConnState, this, std::placeholders::_1), mpAppSettings))
   , mpProcessMonitor(new qst::monitor::ProcessMonitor(mpSyncConnector, mpAppSettings))
-  , mpStartupTab(new qst::settings::StartupTab(mpSyncConnector, mpAppSettings))
+  , mpStartupTab(new qst::settings::StartupTab(mpProcController, mpAppSettings))
   , mpAnimatedIconMovie(new QMovie())
   , mUpdateNotifier(std::bind(&Window::onUpdateCheck, this, std::placeholders::_1),
       QString(tr(currentVersion)), mpAppSettings)
@@ -323,6 +324,7 @@ void Window::monoChromeIconChanged(const int state)
 void Window::pauseSyncthingClicked(const int state)
 {
   mpSyncConnector->pauseSyncthing(state == 1);
+  mpProcController->setPaused(state == 1);
 }
 
 


### PR DESCRIPTION
Fix issues with Standby:

Reset QNetworkAccessManager on `UnknownNetworkError`s.

Cleanup:
Control launching and shutting down the process from a
designated ProcessController.

Previously we managed this from inside the SyncConnector,
but it did not belong there. Now this is handled
properly.

Adresses:
https://github.com/sieren/QSyncthingTray/issues/176
https://github.com/sieren/QSyncthingTray/issues/182