### PR TITLE
Add AppSettings to WebKitView

### DIFF
--- a/includes/qst/syncwebkitview.h
+++ b/includes/qst/syncwebkitview.h
@@ -24,7 +24,7 @@
 
 #include <QNetworkReply>
 #include <QWebView>
-
+#include <qst/appsettings.hpp>
 #include <memory>
 
 //------------------------------------------------------------------------------------//
@@ -54,7 +54,8 @@ class SyncWebKitView : public QWidget
 
 public:
   SyncWebKitView() = default;
-  SyncWebKitView(const QUrl &url, const Authentication &authInfo);
+  SyncWebKitView(const QUrl &url, const Authentication &authInfo,
+                 std::shared_ptr<settings::AppSettings> /*appSetting*/);
   ~SyncWebKitView() = default;
 
   void show();

--- a/sources/qst/syncwebkitview.cpp
+++ b/sources/qst/syncwebkitview.cpp
@@ -32,7 +32,8 @@ namespace webview
 
 //------------------------------------------------------------------------------------//
 
-SyncWebKitView::SyncWebKitView(const QUrl& url, const Authentication &authInfo)
+SyncWebKitView::SyncWebKitView(const QUrl& url, const Authentication &authInfo,
+  std::shared_ptr<settings::AppSettings> /* appSettings */)
   : mSyncThingUrl(url)
   , mAuthInfo(authInfo)
 {


### PR DESCRIPTION
This Commit fixes the missing AppSettings parameter
in the WebKit Based webView functions.

https://github.com/sieren/QSyncthingTray/issues/185