### PR TITLE
Remove CMAKE from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         brew update &&
-        brew install qt5 cmake &&
+        brew install qt5 &&
         chmod -R 755 /usr/local/opt/qt5/* &&
         export QTDIR=$(brew --prefix qt5)
     fi


### PR DESCRIPTION
Cmake is now the correct version by default on Travis.