### PR TITLE
qcustomplot: Fix clang warnings: overrides a member function but is not marked 'override'

### DIFF
--- a/includes/contrib/qcustomplot.h
+++ b/includes/contrib/qcustomplot.h
@@ -3298,7 +3298,7 @@ public:
   void setSelectionDecorator(QCPSelectionDecorator *decorator);
 
   // introduced virtual methods:
-  virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const = 0;
+  virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE = 0;
   virtual QCPPlottableInterface1D *interface1D() { return 0; }
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const = 0;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const = 0;
@@ -3438,7 +3438,7 @@ public:
   QCPAxis *keyAxis() const { return mKeyAxis.data(); }
   QCPAxis *valueAxis() const { return mValueAxis.data(); }
   QCPAxisRect *axisRect() const;
-  virtual QPointF pixelPosition() const;
+  virtual QPointF pixelPosition() const Q_DECL_OVERRIDE;
   
   // setters:
   void setType(PositionType type);
@@ -5995,16 +5995,16 @@ public:
   void addData(double errorMinus, double errorPlus);
   
   // virtual methods of 1d plottable interface:
-  virtual int dataCount() const;
-  virtual double dataMainKey(int index) const;
-  virtual double dataSortKey(int index) const;
-  virtual double dataMainValue(int index) const;
-  virtual QCPRange dataValueRange(int index) const;
-  virtual QPointF dataPixelPosition(int index) const;
-  virtual bool sortKeyIsMainKey() const;
-  virtual QCPDataSelection selectTestRect(const QRectF &rect, bool onlySelectable) const;
-  virtual int findBegin(double sortKey, bool expandedRange=true) const;
-  virtual int findEnd(double sortKey, bool expandedRange=true) const;
+  virtual int dataCount() const Q_DECL_OVERRIDE;
+  virtual double dataMainKey(int index) const Q_DECL_OVERRIDE;
+  virtual double dataSortKey(int index) const Q_DECL_OVERRIDE;
+  virtual double dataMainValue(int index) const Q_DECL_OVERRIDE;
+  virtual QCPRange dataValueRange(int index) const Q_DECL_OVERRIDE;
+  virtual QPointF dataPixelPosition(int index) const Q_DECL_OVERRIDE;
+  virtual bool sortKeyIsMainKey() const Q_DECL_OVERRIDE;
+  virtual QCPDataSelection selectTestRect(const QRectF &rect, bool onlySelectable) const Q_DECL_OVERRIDE;
+  virtual int findBegin(double sortKey, bool expandedRange=true) const Q_DECL_OVERRIDE;
+  virtual int findEnd(double sortKey, bool expandedRange=true) const Q_DECL_OVERRIDE;
   
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;


### PR DESCRIPTION
This happens with clang on at least OS X Sierra: tons of:

```
includes/contrib/qcustomplot.h:3301:18: warning:
     'selectTest' overrides a member function but is not marked 'override'
     [-Winconsistent-missing-override]
```
I understand this is 3rd party code so you might have preferred using the `-Wno-inconsistent-missing-override` at compile-time and leave the file un-modified, but since the warnings are in the header, one would have to disable the warnings for all the QSyncthingTray source files including this header. So, I went for the approach of adding the missing `Q_DECL_OVERRIDE` to the header file. If upstream fixes it, it will fix it in the same way, so there should be no conflicts.

This fix allows to build on OS X with 0 warnings, which is a good thing :-)