### PR TITLE
cmake: use standard CMAKE_PREFIX_PATH way of specifying where to find a custom Qt5 installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,21 +50,18 @@ before_install:
       7z x 5.5.1-0qt5_addons.7z > /dev/null &&
       7z x 5.5.1-0qt5_qtscript.7z > /dev/null &&
       7z x 5.5.1-0qt5_qtlocation.7z > /dev/null &&
-      7z x 5.5.1-0qt5_qtpositioning.7z > /dev/null &&
-      export QTDIR=$PWD/5.5/gcc_64/
+      7z x 5.5.1-0qt5_qtpositioning.7z > /dev/null
     fi
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         brew update &&
         brew install qt5 &&
-        chmod -R 755 /usr/local/opt/qt5/* &&
-        export QTDIR=$(brew --prefix qt5)
+        chmod -R 755 /usr/local/opt/qt5/*
     fi
   
 install:
 
 script:
-      mkdir build
-  &&  cd build
-  &&  cmake ../
-  &&  make
+  - mkdir build && cd build
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cmake -D CMAKE_PREFIX_PATH=../5.5/gcc_64        .. && make ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then cmake -D CMAKE_PREFIX_PATH=$(brew --prefix qt5) .. && make ; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,29 +2,6 @@ cmake_minimum_required(VERSION 3.2)
 
 project (QSyncthingTray)
 
-if ("$ENV{QTDIR}" STREQUAL "")
-  MESSAGE(WARNING "QTDIR not specified. Please export QTDIR
-  e.g. export QTDIR = ~/Qt/5.5/gcc_64/
-  Will try to find system installation..")
-endif ("$ENV{QTDIR}" STREQUAL "")
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  if (${CMAKE_CL_64} MATCHES 0)
-    message (STATUS "MSVC 64 Bit: ${CMAKE_CL_64}")
-    set(CMAKE_PREFIX_PATH "$ENV{QTDIR}")
-  else(${CMAKE_CL_64} MATCHES 0)
-    set(CMAKE_PREFIX_PATH "$ENV{QTDIR}")
-  endif(${CMAKE_CL_64} MATCHES 0)
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(CMAKE_PREFIX_PATH "$ENV{QTDIR}")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  set(CMAKE_PREFIX_PATH "$ENV{QTDIR}")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-
-
-
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
@@ -32,10 +9,14 @@ set(CMAKE_AUTOMOC ON)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-# Find the QtWidgets library
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Network)
-find_package(Qt5PrintSupport)
+find_package(Qt5 5.5 COMPONENTS Widgets Network PrintSupport)
+if (NOT Qt5_FOUND)
+  message(FATAL_ERROR
+    "Some components of Qt5 not found (see above messages for details. "
+    "Did you set CMAKE_PREFIX_PATH ?\n"
+    "Example: cmake -D CMAKE_PREFIX_PATH=/my/path/to/Qt5/5.7/clang_64 .."
+  )
+endif ()
 
 add_definitions(-DGLEW_STATIC)
 # The Qt5Widgets_INCLUDES also includes the include directories for

--- a/README.md
+++ b/README.md
@@ -72,9 +72,8 @@ cmake ../ -G Xcode
 + Get the most recent [Qt Version](http://www.qt.io/download/)
 + Using `cmake`: 
 ```
-export QTDIR=~/Qt/5.5/gcc_64/
 mkdir build && cd build
-cmake ../ && make
+cmake -D CMAKE_PREFIX_PATH=~/Qt/5.5/gcc_64 .. && make -j4
 ```
 
 + Using `qmake`: 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ before_build:
 
 build_script:
   - cd build
-  - cmake ..\ -G "Visual Studio 12 2013 Win64"
+  - cmake -G "Visual Studio 12 2013 Win64" -D CMAKE_PREFIX_PATH=%QTDIR% ..
   - msbuild QSyncthingTray.sln
 
 after_build:


### PR DESCRIPTION
Addresses #190 (Move QTDIR to cmake variable?)

Tested on OS X. Let's see if travis and appveyor are happy...

 I found some other things that can be improved but I will propose them in separate PRs.