### PR TITLE
travis-ci: switch to Sierra (OS X 10.12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: cpp
 
+TODO: google for travis nvm errors in build log
+
+git:
+  # default is 50, not needed
+  depth: 5
+
 matrix:
   include:
     - os: osx
@@ -56,6 +62,7 @@ before_install:
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         brew update &&
+        brew install cmake &&
         brew install qt5 &&
         chmod -R 755 /usr/local/opt/qt5/*
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ matrix:
     - os: osx
       env: CONFIG=Release
       compiler: clang
-      osx_image: xcode7.1
+      # Mac OS X Sierra (10.12)
+      osx_image: xcode8.1
 
 #    - os: linux
 #      env: CONFIG=Release


### PR DESCRIPTION
Implement #193 (travis-ci: move to OS X Sierra)

I am issuing the PR because travis-ci is very slow in this moment for OS X the commit on my fork is in the build queue and it looks like it will stay there for a while.

To your knowledge how are the OS X packages built? With the script in the "scripts" directory? Do we need any change to build the package with Sierra?