### PR TITLE
Improve Startup Tab

### DIFF
--- a/includes/qst/processcontroller.h
+++ b/includes/qst/processcontroller.h
@@ -57,6 +57,8 @@ public:
   ~ProcessController();
   void setPaused(const bool paused);
   void checkAndSpawnINotifyProcess();
+  ProcessState getSyncthingState() const;
+  ProcessState getINotifyState() const;
 
 signals:
   void onNothing(int bla);

--- a/includes/qst/startuptab.hpp
+++ b/includes/qst/startuptab.hpp
@@ -111,8 +111,6 @@ private:
   bool mShouldLaunchSyncthing;
   bool mShouldLaunchINotify;
   bool mShouldShutdownOnExit;
-  QString mCurrentSyncthingPath;
-  QString mCurrentINotifyPath;
 
   std::shared_ptr<process::ProcessController> mpProcController;
   qst::sysutils::SystemUtility systemUtil;

--- a/includes/qst/utilities.hpp
+++ b/includes/qst/utilities.hpp
@@ -172,7 +172,7 @@ static QString trafficToString(T traffic)
 
 //------------------------------------------------------------------------------------//
 
-static auto checkIfFileExists(QString path) -> bool
+inline auto checkIfFileExists(QString path) -> bool
 {
   QFileInfo checkFile(path);
   // check if file exists and if yes: Is it really a file and not a directory?

--- a/sources/qst/processcontroller.cpp
+++ b/sources/qst/processcontroller.cpp
@@ -110,6 +110,63 @@ void ProcessController::notifyProcessSpawned(QProcess::ProcessState newState)
 
 //------------------------------------------------------------------------------------//
 
+auto ProcessController::getSyncthingState() const -> ProcessState
+{
+  if (!mpSyncthingProcess &&
+      mSystemUtil.isBinaryRunning(std::string("syncthing")))
+  {
+    return ProcessState::ALREADY_RUNNING;
+  }
+
+  if (!mpAppSettings->value(kLaunchSyncthingStartupId).toBool())
+  {
+    return ProcessState::NOT_RUNNING;
+  }
+
+  switch (mpSyncthingProcess->state())
+  {
+    case QProcess::Running:
+      return ProcessState::SPAWNED;
+      break;
+    case QProcess::NotRunning:
+      return ProcessState::NOT_RUNNING;
+      break;
+    default:
+      return ProcessState::NOT_RUNNING;
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
+auto ProcessController::getINotifyState() const -> ProcessState
+{
+  if (mSystemUtil.isBinaryRunning(std::string("syncthing-inotify")))
+  {
+    return ProcessState::ALREADY_RUNNING;
+  }
+
+  if (!mpAppSettings->value(kLaunchInotifyStartupId).toBool())
+  {
+    return ProcessState::NOT_RUNNING;
+  }
+
+  switch (mpINotifyProcess->state())
+  {
+    case QProcess::Running:
+      return ProcessState::SPAWNED;
+      break;
+    case QProcess::NotRunning:
+      return ProcessState::NOT_RUNNING;
+      break;
+    default:
+      return ProcessState::NOT_RUNNING;
+  }
+}
+
+
+//------------------------------------------------------------------------------------//
+
 void ProcessController::setPaused(const bool paused)
 {
   if (paused)

--- a/sources/qst/startuptab.cpp
+++ b/sources/qst/startuptab.cpp
@@ -26,15 +26,22 @@ namespace qst
 namespace settings
 {
 
+using namespace process;
+static std::map<ProcessState, QString> stateToString =
+{{ProcessState::ALREADY_RUNNING, "Already Launched"},
+  {ProcessState::NOT_RUNNING, "Not Launched"},
+  {ProcessState::PAUSED, "Paused"},
+  {ProcessState::SPAWNED, "Launched"}};
+
 StartupTab::StartupTab(std::shared_ptr<process::ProcessController> pProcController,
   std::shared_ptr<settings::AppSettings> appSettings) :
     mpProcController(pProcController)
   , mpAppSettings(appSettings)
 {
   
-  loadSettings();
   connect(mpProcController.get(), &process::ProcessController::onProcessSpawned,
     this, &StartupTab::processSpawnedChanged);
+  loadSettings();
   initGUI();
 }
 
@@ -60,7 +67,7 @@ void StartupTab::initGUI()
   mpFilePathLine = new QLineEdit(mpAppSettings->value(kSyncthingPathId).toString());
   mpFilePathBrowse = new QPushButton(tr("Browse"));
   
-  mpAppSpawnedLabel = new QLabel(tr("Not started"));
+  mpAppSpawnedLabel = new QLabel(stateToString.at(mpProcController->getSyncthingState()));
 
   mpShutdownOnExitBox = new QCheckBox(tr("Shutdown on Exit"));
   Qt::CheckState shutdownState = mShouldShutdownOnExit ? Qt::Checked : Qt::Unchecked;
@@ -87,7 +94,7 @@ void StartupTab::initGUI()
   
   mpiNotifyGroupBox = new QGroupBox(tr("iNotify Application"));
 
-  mpINotifySpawnedLabel = new QLabel(tr("Not started"));
+  mpINotifySpawnedLabel = new QLabel(stateToString.at(mpProcController->getINotifyState()));
   mpShouldLaunchINotify = new QCheckBox(tr("Launch iNotify"));
   Qt::CheckState iNotifylaunchState = mShouldLaunchINotify ? Qt::Checked : Qt::Unchecked;
   mpShouldLaunchINotify->setCheckState(iNotifylaunchState);

--- a/sources/qst/startuptab.cpp
+++ b/sources/qst/startuptab.cpp
@@ -57,7 +57,7 @@ void StartupTab::initGUI()
   mpShouldLaunchSyncthingBox->setCheckState(launchState);
   QGridLayout *filePathLayout = new QGridLayout;
   
-  mpFilePathLine = new QLineEdit(mCurrentSyncthingPath);
+  mpFilePathLine = new QLineEdit(mpAppSettings->value(kSyncthingPathId).toString());
   mpFilePathBrowse = new QPushButton(tr("Browse"));
   
   mpAppSpawnedLabel = new QLabel(tr("Not started"));
@@ -93,7 +93,7 @@ void StartupTab::initGUI()
   mpShouldLaunchINotify->setCheckState(iNotifylaunchState);
   QGridLayout *iNotifyLayout = new QGridLayout;
 
-  mpINotifyFilePath = new QLineEdit(mCurrentINotifyPath);
+  mpINotifyFilePath = new QLineEdit(mpAppSettings->value(kInotifyPathId).toString());
   mpINotifyBrowse = new QPushButton(tr("Browse"));
 
   iNotifyLayout->addWidget(mpINotifyFilePath,2, 0, 1, 4);
@@ -166,7 +166,6 @@ void StartupTab::showFileBrowser()
     tr("Open Syncthing"), "", tr(""));
   if (!filename.isEmpty())
   {
-    mCurrentSyncthingPath = filename;
     mpFilePathLine->setText(filename);
   }
   saveSettings();
@@ -237,9 +236,9 @@ void StartupTab::saveSettings()
     return;
   }
   mpAppSettings->setValues(
-    make_pair(kSyncthingPathId, mCurrentSyncthingPath),
+    make_pair(kSyncthingPathId, mpFilePathLine->text()),
     make_pair(kLaunchSyncthingStartupId, mShouldLaunchSyncthing),
-    make_pair(kInotifyPathId, mCurrentINotifyPath),
+    make_pair(kInotifyPathId, mpINotifyFilePath->text()),
     make_pair(kLaunchInotifyStartupId, mShouldLaunchINotify),
     make_pair(kShutDownExitId, mShouldShutdownOnExit));
 }
@@ -249,9 +248,7 @@ void StartupTab::saveSettings()
 
 void StartupTab::loadSettings()
 {
-  mCurrentSyncthingPath = mpAppSettings->value(kSyncthingPathId).toString();
   mShouldLaunchSyncthing = mpAppSettings->value(kLaunchSyncthingStartupId).toBool();
-  mCurrentINotifyPath = mpAppSettings->value(kInotifyPathId).toString();
   mShouldLaunchINotify = mpAppSettings->value(kLaunchInotifyStartupId).toBool();
   mShouldShutdownOnExit = mpAppSettings->value(kShutDownExitId).toBool();
 }

--- a/sources/qst/startuptab.cpp
+++ b/sources/qst/startuptab.cpp
@@ -228,14 +228,16 @@ void StartupTab::saveSettings()
 {
   using namespace std;
   // Check Filepath Validity
-  if (!mpFilePathLine->text().isEmpty() &&
+  if (mShouldLaunchSyncthing &&
+      !mpFilePathLine->text().isEmpty() &&
       !utilities::checkIfFileExists(mpFilePathLine->text()))
   {
     displayPathNotFound("Syncthing");
   }
 
   // Check Filepath Validity
-  if (!mpINotifyFilePath->text().isEmpty() &&
+  if (mShouldLaunchINotify &&
+      !mpINotifyFilePath->text().isEmpty() &&
       !utilities::checkIfFileExists(mpINotifyFilePath->text()))
   {
     displayPathNotFound("syncthing-inotify");

--- a/sources/qst/startuptab.cpp
+++ b/sources/qst/startuptab.cpp
@@ -225,7 +225,6 @@ void StartupTab::saveSettings()
       !utilities::checkIfFileExists(mpFilePathLine->text()))
   {
     displayPathNotFound("Syncthing");
-    return;
   }
 
   // Check Filepath Validity
@@ -233,7 +232,6 @@ void StartupTab::saveSettings()
       !utilities::checkIfFileExists(mpINotifyFilePath->text()))
   {
     displayPathNotFound("syncthing-inotify");
-    return;
   }
   mpAppSettings->setValues(
     make_pair(kSyncthingPathId, mpFilePathLine->text()),


### PR DESCRIPTION
Generally improve the startup tab:
Fix a bug where iNotify Paths wouldnt be saved correctly.
Improve visual feedback immediacy on process states.

Adresses: 
https://github.com/sieren/QSyncthingTray/issues/205
https://github.com/sieren/QSyncthingTray/issues/206