### PR TITLE
Set OSX Deployment Target to 10.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
 
 project (QSyncthingTray LANGUAGES CXX)
 


### PR DESCRIPTION
Explicitly set the OSX Deployment target or else clang
would assume the most recent installed OSX version.

Fixes https://github.com/sieren/QSyncthingTray/issues/218