### PR TITLE
Add native browser support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ before_install:
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         brew update &&
-        brew install cmake &&
         brew install qt5 &&
         chmod -R 755 /usr/local/opt/qt5/*
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
 
 project (QSyncthingTray LANGUAGES CXX)
 
-set(QSYNCTHINGTRAY_VERSION 0.5.8)
+set(QSYNCTHINGTRAY_VERSION 0.5.9)
 set(QSYNCTHINGTRAY_COPYRIGHT_YEARS 2015-2017)
 
 # Find includes in corresponding build directories
@@ -128,6 +128,9 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 if (${QST_BUILD_WEBKIT})
   qt5_use_modules(QSyncthingTray Widgets Network WebKitWidgets)
   target_compile_definitions(QSyncthingTray PRIVATE BUILD_WEBKIT=1)
+elseif (${QST_BUILD_NATIVEBROWSER})
+  qt5_use_modules(QSyncthingTray Widgets Network)
+  target_compile_definitions(QSyncthingTray PRIVATE BUILD_NATIVEBROWSER=1)
 else()
   qt5_use_modules(QSyncthingTray Widgets Network WebEngineWidgets)
 endif()

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you want to use HTTPS to connect to Syncthing on Windows, please download and
 
 ## Build & Run
 + Get a recent version of Qt (5.5+)  
-+ QSyncthingTray can be either built with QWebEngine or QtWebView. By default it is built with QWebEngine. To enable QWebView pass `-DQST_BUILD_WEBKIT=1` as an argument to `cmake`.  
++ QSyncthingTray can be either built with QWebEngine, QtWebView or native Browser support. By default it is built with QWebEngine. To enable QWebView pass `-DQST_BUILD_WEBKIT=1` as an argument to `cmake`. For native browser support: `-DQST_BUILD_NATIVEBROWSER=1`.
 
 ### Mac & Windows
 + Use either QtCreator or create an XCode or Visual Studio Project with CMake or QMake.  

--- a/includes/CMakeLists.txt
+++ b/includes/CMakeLists.txt
@@ -32,6 +32,11 @@ if (${QST_BUILD_WEBKIT})
     ${qst_HEADERS}
     ${qst_include_ROOT}/syncwebkitview.h
   )
+elseif (${QST_BUILD_NATIVEBROWSER})
+  set(qst_HEADERS
+    ${qst_HEADERS}
+    ${qst_include_ROOT}/syncnativebrowser.h
+  )
 else()
   set(qst_HEADERS
     ${qst_HEADERS}

--- a/includes/qst/syncnativebrowser.h
+++ b/includes/qst/syncnativebrowser.h
@@ -1,0 +1,75 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
+#ifndef SYNCNATIVEBROWSER_H
+#define SYNCNATIVEBROWSER_H
+
+#include <QObject>
+#include <memory>
+#include "utilities.hpp"
+#include "syncwebpage.h"
+#include <qst/appsettings.hpp>
+
+//------------------------------------------------------------------------------------//
+
+namespace qst
+{
+namespace webview
+{
+
+//------------------------------------------------------------------------------------//
+
+static const bool kWebViewSupportsZoom = false;
+
+//------------------------------------------------------------------------------------//
+
+class SyncNativeBrowser : public QObject
+{
+  Q_OBJECT;
+public:
+  SyncNativeBrowser() = default;
+  SyncNativeBrowser(QUrl url,
+              Authentication authInfo,
+              std::shared_ptr<settings::AppSettings> appSettings);
+  ~SyncNativeBrowser() = default;
+  
+  void show();
+  bool isVisible() const; // NOOP
+  void raise(); // NOOP
+  void setZoomFactor(double value); // NOOP
+  void updateConnection(const QUrl &url, const Authentication &authInfo);
+
+signals:
+  void close();
+
+private:
+  QUrl mSyncThingUrl;
+  Authentication mAuthInfo;
+  std::shared_ptr<settings::AppSettings> mpAppSettings;
+};
+
+  
+} // qst namespace
+} // webview namespace
+
+#endif // SYNCNATIVEBROWSER_H
+
+//------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------//
+// EOF
+//------------------------------------------------------------------------------------//

--- a/includes/qst/webview.h
+++ b/includes/qst/webview.h
@@ -20,6 +20,8 @@
 
 #ifdef BUILD_WEBKIT
 #include <qst/syncwebkitview.h>
+#elif defined(BUILD_NATIVEBROWSER)
+#include <qst/syncnativebrowser.h>
 #else
 #include <qst/syncwebview.h>
 #include <qst/syncwebpage.h>
@@ -32,6 +34,8 @@ namespace webview
 
 #ifdef BUILD_WEBKIT
 using WebView = qst::webview::SyncWebKitView;
+#elif defined(BUILD_NATIVEBROWSER)
+using WebView = qst::webview::SyncNativeBrowser;
 #else
 using WebView = qst::webview::SyncWebView;
 #endif

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -26,6 +26,11 @@ if (${QST_BUILD_WEBKIT})
     ${qst_SOURCES}
     ${qst_src_ROOT}/syncwebkitview.cpp
   )
+elseif (${QST_BUILD_NATIVEBROWSER})
+  set(qst_SOURCES
+    ${qst_SOURCES}
+    ${qst_src_ROOT}/syncnativebrowser.cpp
+  )
 else()
   set(qst_SOURCES
     ${qst_SOURCES}

--- a/sources/qst/syncnativebrowser.cpp
+++ b/sources/qst/syncnativebrowser.cpp
@@ -1,0 +1,93 @@
+/******************************************************************************
+ // QSyncthingTray
+ // Copyright (c) Matthias Frick, All rights reserved.
+ //
+ // This library is free software; you can redistribute it and/or
+ // modify it under the terms of the GNU Lesser General Public
+ // License as published by the Free Software Foundation; either
+ // version 3.0 of the License, or (at your option) any later version.
+ //
+ // This library is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ // Lesser General Public License for more details.
+ //
+ // You should have received a copy of the GNU Lesser General Public
+ // License along with this library.
+ ******************************************************************************/
+
+
+#include <qst/syncnativebrowser.h>
+#include <QContextMenuEvent>
+#include <functional>
+#include <QDesktopServices>
+
+
+//------------------------------------------------------------------------------------//
+#define UNUSED(x) (void)(x)
+//------------------------------------------------------------------------------------//
+
+namespace qst
+{
+namespace webview
+{
+
+//------------------------------------------------------------------------------------//
+
+
+SyncNativeBrowser::SyncNativeBrowser(QUrl url, Authentication authInfo,
+                         std::shared_ptr<settings::AppSettings> appSettings) :
+mSyncThingUrl(url)
+,mAuthInfo(authInfo)
+,mpAppSettings(appSettings)
+{
+}
+
+//------------------------------------------------------------------------------------//
+
+void SyncNativeBrowser::updateConnection(const QUrl &url, const Authentication &authInfo)
+{
+  mSyncThingUrl = url;
+  mAuthInfo = authInfo;
+}
+
+
+//------------------------------------------------------------------------------------//
+
+bool SyncNativeBrowser::isVisible() const
+{
+  return false;
+}
+
+
+//------------------------------------------------------------------------------------//
+
+void SyncNativeBrowser::setZoomFactor(double value)
+{
+  UNUSED(value);
+// NOOP
+}
+
+
+//------------------------------------------------------------------------------------//
+  
+void SyncNativeBrowser::raise()
+{
+// NOOP
+}
+ 
+
+//------------------------------------------------------------------------------------//
+
+void SyncNativeBrowser::show()
+{
+  QDesktopServices::openUrl(QUrl(mSyncThingUrl));
+}
+
+} // qst namespace
+} // webview namespace
+
+//------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------//
+// EOF
+//------------------------------------------------------------------------------------//


### PR DESCRIPTION
Add a compile flag that enables native browser support,
thus getting rid off the WebEngine dependency.

Adresses: https://github.com/sieren/QSyncthingTray/issues/224