### PR TITLE
Bugfix: Notification Settings not saved

### DIFF
--- a/sources/qst/window.cpp
+++ b/sources/qst/window.cpp
@@ -726,7 +726,8 @@ void Window::saveSettings()
     make_pair(kIconAnimcationsEnabledId, mShouldAnimateIcon),
     make_pair(kPollingIntervalId, mpSyncPollIntervalBox->value()),
     make_pair(kApiKeyId, mpAPIKeyEdit->text()),
-    make_pair(kStatsLengthId, static_cast<int>(mpStatsLengthBox->value())));
+    make_pair(kStatsLengthId, static_cast<int>(mpStatsLengthBox->value())),
+    make_pair(kNotificationsEnabledId, mNotificationsEnabled));
 }
 
 


### PR DESCRIPTION
Add missing KV Pair to settings routine.

Fixes: https://github.com/sieren/QSyncthingTray/issues/222