### PR TITLE
Make traffic stats accurate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,9 @@ before_install:
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
         brew update &&
+        brew upgrade cmake &&
         brew install qt5 &&
+        brew install jsoncpp &&
         chmod -R 755 /usr/local/opt/qt5/*
     fi
   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ if (NOT Qt5_FOUND)
   )
 endif ()
 
+find_package(PkgConfig)
+pkg_check_modules(JSONCPP jsoncpp)
+
 # Fill the template with information gathered from CMake.
 configure_file(includes/config.template.h config.h @ONLY)
 
@@ -29,6 +32,10 @@ add_definitions(-DGLEW_STATIC)
 # The Qt5Widgets_INCLUDES also includes the include directories for
 # dependencies QtCore and QtGui
 include_directories(${Qt5Widgets_INCLUDES})
+if (${JSONCPP_FOUND})
+    add_definitions(-DHAVE_JSONCPP)
+    include_directories(${JSONCPP_INCLUDE_DIRS})
+endif ()
 
 # We need add -DQT_WIDGETS_LIB when using QtWidgets in Qt 5.
 add_definitions(${Qt5Widgets_DEFINITIONS})
@@ -135,6 +142,10 @@ else()
   find_package(Qt5 REQUIRED COMPONENTS WebEngineWidgets)
   target_link_libraries(QSyncthingTray Qt5::Widgets Qt5::Network Qt5::WebEngineWidgets)
 endif()
+
+if (${JSONCPP_FOUND})
+    target_link_libraries(QSyncthingTray ${JSONCPP_LINK_LIBRARIES})
+endif ()
 
 
 # Temporary solution/hack to generate package.


### PR DESCRIPTION
Qt's QJson can't handle large integers [1]. As a result traffic statistics is inaccurate when tens of gigabytes are transferred. On the other hand, jsoncpp can handle 64-bit integers, which are sufficient as syncthing uses 64-bit integers, too [2].

To see the effects of inaccurate statistics, trasnfer 10GB of data within syncthing and then transfer some tiny files (e.g., a few KB). You will see the tray icon rotates for a long time.

Not sure if it's a good idea or not to add one more dependency. jsoncpp is a dependency of cmake, so it should already be there if one can build QSyncthingTray. I can also try to make jsoncpp optional and fallback to QJson if you wish.

[1] https://bugreports.qt.io/browse/QTBUG-28560
[2] https://github.com/syncthing/syncthing/blob/v1.1.4/lib/protocol/protocol.go#L905-L909